### PR TITLE
fix _non_dist_train

### DIFF
--- a/mmedit/apis/train.py
+++ b/mmedit/apis/train.py
@@ -247,4 +247,4 @@ def _non_dist_train(model,
         runner.resume(cfg.resume_from)
     elif cfg.load_from:
         runner.load_checkpoint(cfg.load_from)
-    runner.run(data_loaders, cfg.workflow, cfg.total_epochs)
+    runner.run(data_loaders, cfg.workflow, cfg.total_iters)


### PR DESCRIPTION
IterBasedRunner: `cfg` only has `total_iters`.