### PR TITLE
Fix setup.py get_hash bug

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ def get_hash():
         sha = get_git_hash()[:7]
     elif os.path.exists(version_file):
         try:
-            from mmdet.version import __version__
+            from mmedit.version import __version__
             sha = __version__.split('+')[-1]
         except ImportError:
             raise ImportError('Unable to get git version')


### PR DESCRIPTION
Try to fix #123
`setup.py` has a mistake during getting the version of the package. 