### PR TITLE
Refactor loader_cfg.

### DIFF
--- a/mmedit/apis/train.py
+++ b/mmedit/apis/train.py
@@ -167,7 +167,8 @@ def _dist_train(model,
                           'https://github.com/open-mmlab/mmediting/pull/201')
 
         val_loader_cfg = {
-            **dict(loader_cfg, shuffle=False, drop_last=False),
+            **loader_cfg,
+            **dict(shuffle=False, drop_last=False),
             **dict((newk, cfg.data[oldk]) for oldk, newk in [
                        ('val_samples_per_gpu', 'samples_per_gpu'),
                        ('val_workers_per_gpu', 'workers_per_gpu'),
@@ -276,7 +277,8 @@ def _non_dist_train(model,
                           'https://github.com/open-mmlab/mmediting/pull/201')
 
         val_loader_cfg = {
-            **dict(loader_cfg, shuffle=False, drop_last=False),
+            **loader_cfg,
+            **dict(shuffle=False, drop_last=False),
             **dict((newk, cfg.data[oldk]) for oldk, newk in [
                        ('val_samples_per_gpu', 'samples_per_gpu'),
                        ('val_workers_per_gpu', 'workers_per_gpu'),

--- a/mmedit/apis/train.py
+++ b/mmedit/apis/train.py
@@ -102,24 +102,20 @@ def _dist_train(model,
 
     # step 1: give default values and override (if exist) from cfg.data
     loader_cfg = {
-        **dict(
-            seed=cfg.get('seed'),
-            drop_last=False,
-            dist=True,
-        ),
-        **dict({} if torch.__version__ != 'parrots' else dict(
-            prefetch_num=2,
-            pin_memory=False,
-        )),
+        **dict(seed=cfg.get('seed'), drop_last=False, dist=True),
+        **({} if torch.__version__ != 'parrots' else dict(
+               prefetch_num=2,
+               pin_memory=False,
+           )),
         **dict((k, cfg.data[k]) for k in [
-            'samples_per_gpu',
-            'workers_per_gpu',
-            'shuffle',
-            'seed',
-            'drop_last',
-            'prefetch_num',
-            'pin_memory',
-        ] if k in cfg.data))
+                   'samples_per_gpu',
+                   'workers_per_gpu',
+                   'shuffle',
+                   'seed',
+                   'drop_last',
+                   'prefetch_num',
+                   'pin_memory',
+               ] if k in cfg.data)
     }
 
     # step 2: cfg.data.train_dataloader has highest priority
@@ -171,15 +167,11 @@ def _dist_train(model,
                           'https://github.com/open-mmlab/mmediting/pull/201')
 
         val_loader_cfg = {
-            **dict(
-                loader_cfg,
-                shuffle=False,
-                drop_last=False,
-            ),
+            **dict(loader_cfg, shuffle=False, drop_last=False),
             **dict((newk, cfg.data[oldk]) for oldk, newk in [
-                ('val_samples_per_gpu', 'samples_per_gpu'),
-                ('val_workers_per_gpu', 'workers_per_gpu'),
-            ] if oldk in cfg.data),
+                       ('val_samples_per_gpu', 'samples_per_gpu'),
+                       ('val_workers_per_gpu', 'workers_per_gpu'),
+                   ] if oldk in cfg.data),
             **cfg.data.get('val_dataloader', {})
         }
 
@@ -219,24 +211,24 @@ def _non_dist_train(model,
 
     # step 1: give default values and override (if exist) from cfg.data
     loader_cfg = {
-        **dict(seed=cfg.get('seed'),
+        **dict(
+            seed=cfg.get('seed'),
             drop_last=False,
             dist=False,
-            num_gpus=cfg.gpus
-        ),
-        **dict({} if torch.__version__ != 'parrots' else dict(
-            prefetch_num=2,
-            pin_memory=False,
-        )),
+            num_gpus=cfg.gpus),
+        **({} if torch.__version__ != 'parrots' else dict(
+               prefetch_num=2,
+               pin_memory=False,
+           )),
         **dict((k, cfg.data[k]) for k in [
-            'samples_per_gpu',
-            'workers_per_gpu',
-            'shuffle',
-            'seed',
-            'drop_last',
-            'prefetch_num',
-            'pin_memory',
-        ] if k in cfg.data)
+                   'samples_per_gpu',
+                   'workers_per_gpu',
+                   'shuffle',
+                   'seed',
+                   'drop_last',
+                   'prefetch_num',
+                   'pin_memory',
+               ] if k in cfg.data)
     }
 
     # step 2: cfg.data.train_dataloader has highest priority
@@ -284,16 +276,12 @@ def _non_dist_train(model,
                           'https://github.com/open-mmlab/mmediting/pull/201')
 
         val_loader_cfg = {
-            **dict(
-                loader_cfg,
-                shuffle=False,
-                drop_last=False,
-            ),
+            **dict(loader_cfg, shuffle=False, drop_last=False),
             **dict((newk, cfg.data[oldk]) for oldk, newk in [
-                ('val_samples_per_gpu', 'samples_per_gpu'),
-                ('val_workers_per_gpu', 'workers_per_gpu'),
-            ] if oldk in cfg.data),
-            **cfg.data.get('val_dataloader', {}))
+                       ('val_samples_per_gpu', 'samples_per_gpu'),
+                       ('val_workers_per_gpu', 'workers_per_gpu'),
+                   ] if oldk in cfg.data),
+            **cfg.data.get('val_dataloader', {})
         }
 
         data_loader = build_dataloader(dataset, **val_loader_cfg)

--- a/mmedit/apis/train.py
+++ b/mmedit/apis/train.py
@@ -101,10 +101,12 @@ def _dist_train(model,
     dataset = dataset if isinstance(dataset, (list, tuple)) else [dataset]
 
     # step 1: give default values and override (if exist) from cfg.data
-    loader_cfg = dict(
-        seed=cfg.get('seed'),
-        drop_last=False,
-        dist=True,
+    loader_cfg = {
+        **dict(
+            seed=cfg.get('seed'),
+            drop_last=False,
+            dist=True,
+        ),
         **({} if torch.__version__ != 'parrots' else dict(
             prefetch_num=2,
             pin_memory=False,
@@ -118,6 +120,7 @@ def _dist_train(model,
             'prefetch_num',
             'pin_memory',
         ] if k in cfg.data))
+    }
 
     # step 2: cfg.data.train_dataloader has highest priority
     train_loader_cfg = dict(loader_cfg, **cfg.data.get('train_dataloader', {}))
@@ -167,15 +170,18 @@ def _dist_train(model,
                           'Details see '
                           'https://github.com/open-mmlab/mmediting/pull/201')
 
-        val_loader_cfg = dict(
-            loader_cfg,
-            shuffle=False,
-            drop_last=False,
+        val_loader_cfg = {
+            **dict(
+                loader_cfg,
+                shuffle=False,
+                drop_last=False,
+            ),
             **dict((newk, cfg.data[oldk]) for oldk, newk in [
                 ('val_samples_per_gpu', 'samples_per_gpu'),
                 ('val_workers_per_gpu', 'workers_per_gpu'),
             ] if oldk in cfg.data),
-            **cfg.data.get('val_dataloader', {}))
+            **cfg.data.get('val_dataloader', {})
+        }
 
         data_loader = build_dataloader(dataset, **val_loader_cfg)
         save_path = osp.join(cfg.work_dir, 'val_visuals')
@@ -275,15 +281,18 @@ def _non_dist_train(model,
                           'Details see '
                           'https://github.com/open-mmlab/mmediting/pull/201')
 
-        val_loader_cfg = dict(
-            loader_cfg,
-            shuffle=False,
-            drop_last=False,
+        val_loader_cfg = {
+            **dict(
+                loader_cfg,
+                shuffle=False,
+                drop_last=False,
+            ),
             **dict((newk, cfg.data[oldk]) for oldk, newk in [
                 ('val_samples_per_gpu', 'samples_per_gpu'),
                 ('val_workers_per_gpu', 'workers_per_gpu'),
             ] if oldk in cfg.data),
             **cfg.data.get('val_dataloader', {}))
+        }
 
         data_loader = build_dataloader(dataset, **val_loader_cfg)
         save_path = osp.join(cfg.work_dir, 'val_visuals')

--- a/mmedit/apis/train.py
+++ b/mmedit/apis/train.py
@@ -107,7 +107,7 @@ def _dist_train(model,
             drop_last=False,
             dist=True,
         ),
-        **({} if torch.__version__ != 'parrots' else dict(
+        **dict({} if torch.__version__ != 'parrots' else dict(
             prefetch_num=2,
             pin_memory=False,
         )),
@@ -218,12 +218,13 @@ def _non_dist_train(model,
     dataset = dataset if isinstance(dataset, (list, tuple)) else [dataset]
 
     # step 1: give default values and override (if exist) from cfg.data
-    loader_cfg = dict(
-        seed=cfg.get('seed'),
-        drop_last=False,
-        dist=False,
-        num_gpus=cfg.gpus,
-        **({} if torch.__version__ != 'parrots' else dict(
+    loader_cfg = {
+        **dict(seed=cfg.get('seed'),
+            drop_last=False,
+            dist=False,
+            num_gpus=cfg.gpus
+        ),
+        **dict({} if torch.__version__ != 'parrots' else dict(
             prefetch_num=2,
             pin_memory=False,
         )),
@@ -235,7 +236,8 @@ def _non_dist_train(model,
             'drop_last',
             'prefetch_num',
             'pin_memory',
-        ] if k in cfg.data))
+        ] if k in cfg.data)
+    }
 
     # step 2: cfg.data.train_dataloader has highest priority
     train_loader_cfg = dict(loader_cfg, **cfg.data.get('train_dataloader', {}))

--- a/tools/test.py
+++ b/tools/test.py
@@ -77,8 +77,8 @@ def main():
         samples_per_gpu=1,
         drop_last=False,
         shuffle=False,
-        **cfg.data.get('test_dataloader', {}),
         dist=distributed)
+    loader_cfg.update(cfg.data.get('test_dataloader', {}))
 
     data_loader = build_dataloader(dataset, **loader_cfg)
 

--- a/tools/test.py
+++ b/tools/test.py
@@ -74,11 +74,13 @@ def main():
 
     loader_cfg = {
         **dict((k, cfg.data[k]) for k in ['workers_per_gpu'] if k in cfg.data),
-        **dict(samples_per_gpu=1,
+        **dict(
+            samples_per_gpu=1,
             drop_last=False,
             shuffle=False,
             dist=distributed),
-        **cfg.data.get('test_dataloader', {})}
+        **cfg.data.get('test_dataloader', {})
+    }
 
     data_loader = build_dataloader(dataset, **loader_cfg)
 

--- a/tools/test.py
+++ b/tools/test.py
@@ -72,13 +72,13 @@ def main():
     # TODO: support multiple images per gpu (only minor changes are needed)
     dataset = build_dataset(cfg.data.test)
 
-    loader_cfg = dict(
-        dict((k, cfg.data[k]) for k in ['workers_per_gpu'] if k in cfg.data),
-        samples_per_gpu=1,
-        drop_last=False,
-        shuffle=False,
-        dist=distributed)
-    loader_cfg.update(cfg.data.get('test_dataloader', {}))
+    loader_cfg = {
+        **dict((k, cfg.data[k]) for k in ['workers_per_gpu'] if k in cfg.data),
+        **dict(samples_per_gpu=1,
+            drop_last=False,
+            shuffle=False,
+            dist=distributed),
+        **cfg.data.get('test_dataloader', {})}
 
     data_loader = build_dataloader(dataset, **loader_cfg)
 


### PR DESCRIPTION
Refactor loader_cfg of main() in tools/test.py.

There is a bug in the master branch:
`TypeError: type object got multiple values for keyword argument 'samples_per_gpu'`.

That is because `loader_cfg` contains two `'samples_per_gpu'`:

1. `samples_per_gpu=1,`
2. ` **cfg.data.get('test_dataloader', {}),`, while `cfg.data['test_dataloader']=dict(samples_per_gpu=1),`

The second one has been replaced by `loader_cfg.update(cfg.data.get('test_dataloader', {}))`.