### PR TITLE
Add MirrorExtend for training BasicVSR and IconVSR

### DIFF
--- a/mmedit/datasets/pipelines/__init__.py
+++ b/mmedit/datasets/pipelines/__init__.py
@@ -1,8 +1,7 @@
 from .augmentation import (BinarizeImage, Flip, GenerateFrameIndices,
-                           GenerateFrameIndiceswithPadding,
-                           MirrorSequenceExtend, Pad, RandomAffine,
-                           RandomJitter, RandomMaskDilation, RandomTransposeHW,
-                           Resize, TemporalReverse)
+                           GenerateFrameIndiceswithPadding, MirrorSequence,
+                           Pad, RandomAffine, RandomJitter, RandomMaskDilation,
+                           RandomTransposeHW, Resize, TemporalReverse)
 from .compose import Compose
 from .crop import (Crop, CropAroundCenter, CropAroundFg, CropAroundUnknown,
                    FixedCrop, ModCrop, PairedRandomCrop)
@@ -30,5 +29,5 @@ __all__ = [
     'LoadPairedImageFromFile', 'GenerateSoftSeg', 'GenerateSeg', 'PerturbBg',
     'CropAroundFg', 'GetSpatialDiscountMask', 'RandomDownSampling',
     'GenerateTrimapWithDistTransform', 'TransformTrimap',
-    'GenerateCoordinateAndCell', 'MirrorSequenceExtend'
+    'GenerateCoordinateAndCell', 'MirrorSequence'
 ]

--- a/mmedit/datasets/pipelines/__init__.py
+++ b/mmedit/datasets/pipelines/__init__.py
@@ -1,7 +1,7 @@
 from .augmentation import (BinarizeImage, Flip, GenerateFrameIndices,
-                           GenerateFrameIndiceswithPadding, Pad, RandomAffine,
-                           RandomJitter, RandomMaskDilation, RandomTransposeHW,
-                           Resize, TemporalReverse)
+                           GenerateFrameIndiceswithPadding, MirrorExtend, Pad,
+                           RandomAffine, RandomJitter, RandomMaskDilation,
+                           RandomTransposeHW, Resize, TemporalReverse)
 from .compose import Compose
 from .crop import (Crop, CropAroundCenter, CropAroundFg, CropAroundUnknown,
                    FixedCrop, ModCrop, PairedRandomCrop)
@@ -29,5 +29,5 @@ __all__ = [
     'LoadPairedImageFromFile', 'GenerateSoftSeg', 'GenerateSeg', 'PerturbBg',
     'CropAroundFg', 'GetSpatialDiscountMask', 'RandomDownSampling',
     'GenerateTrimapWithDistTransform', 'TransformTrimap',
-    'GenerateCoordinateAndCell'
+    'GenerateCoordinateAndCell', 'MirrorExtend'
 ]

--- a/mmedit/datasets/pipelines/__init__.py
+++ b/mmedit/datasets/pipelines/__init__.py
@@ -1,7 +1,8 @@
 from .augmentation import (BinarizeImage, Flip, GenerateFrameIndices,
-                           GenerateFrameIndiceswithPadding, MirrorExtend, Pad,
-                           RandomAffine, RandomJitter, RandomMaskDilation,
-                           RandomTransposeHW, Resize, TemporalReverse)
+                           GenerateFrameIndiceswithPadding,
+                           MirrorSequenceExtend, Pad, RandomAffine,
+                           RandomJitter, RandomMaskDilation, RandomTransposeHW,
+                           Resize, TemporalReverse)
 from .compose import Compose
 from .crop import (Crop, CropAroundCenter, CropAroundFg, CropAroundUnknown,
                    FixedCrop, ModCrop, PairedRandomCrop)
@@ -29,5 +30,5 @@ __all__ = [
     'LoadPairedImageFromFile', 'GenerateSoftSeg', 'GenerateSeg', 'PerturbBg',
     'CropAroundFg', 'GetSpatialDiscountMask', 'RandomDownSampling',
     'GenerateTrimapWithDistTransform', 'TransformTrimap',
-    'GenerateCoordinateAndCell', 'MirrorExtend'
+    'GenerateCoordinateAndCell', 'MirrorSequenceExtend'
 ]

--- a/mmedit/datasets/pipelines/augmentation.py
+++ b/mmedit/datasets/pipelines/augmentation.py
@@ -898,7 +898,7 @@ class TemporalReverse:
 
 
 @PIPELINES.register_module()
-class MirrorSequenceExtend:
+class MirrorSequence:
     """Extend short sequences (e.g. Vimeo-90K) by mirroring the sequences
 
     Given a sequence with N frames (x1, ..., xN), extend the sequence to

--- a/mmedit/datasets/pipelines/augmentation.py
+++ b/mmedit/datasets/pipelines/augmentation.py
@@ -895,3 +895,42 @@ class TemporalReverse:
         repr_str = self.__class__.__name__
         repr_str += f'(keys={self.keys}, reverse_ratio={self.reverse_ratio})'
         return repr_str
+
+
+@PIPELINES.register_module()
+class MirrorExtend:
+    """Extend short sequences (e.g. Vimeo-90K) by mirroring the sequences
+
+    Given a sequence with N frames (x1, ..., xN), extend the sequence to
+    (x1, ..., xN, xN, ..., x1).
+
+    Args:
+        keys (list[str]): The frame lists to be extended.
+    """
+
+    def __init__(self, keys):
+        self.keys = keys
+
+    def __call__(self, results):
+        """Call function.
+
+        Args:
+            results (dict): A dict containing the necessary information and
+                data for augmentation.
+
+        Returns:
+            dict: A dict containing the processed data and information.
+        """
+        for key in self.keys:
+            if isinstance(results[key], list):
+                results[key] = results[key] + results[key][::-1]
+            else:
+                raise TypeError('The input must be of class list[nparray]. '
+                                f'Got {type(results[key])}.')
+
+        return results
+
+    def __repr__(self):
+        repr_str = self.__class__.__name__
+        repr_str += (f'(keys={self.keys})')
+        return repr_str

--- a/mmedit/datasets/pipelines/augmentation.py
+++ b/mmedit/datasets/pipelines/augmentation.py
@@ -898,7 +898,7 @@ class TemporalReverse:
 
 
 @PIPELINES.register_module()
-class MirrorExtend:
+class MirrorSequenceExtend:
     """Extend short sequences (e.g. Vimeo-90K) by mirroring the sequences
 
     Given a sequence with N frames (x1, ..., xN), extend the sequence to

--- a/tests/test_augmentation.py
+++ b/tests/test_augmentation.py
@@ -8,7 +8,7 @@ import torch
 from mmedit.datasets.pipelines import (BinarizeImage, Flip,
                                        GenerateFrameIndices,
                                        GenerateFrameIndiceswithPadding,
-                                       MirrorExtend, Pad, RandomAffine,
+                                       MirrorSequenceExtend, Pad, RandomAffine,
                                        RandomJitter, RandomMaskDilation,
                                        RandomTransposeHW, Resize,
                                        TemporalReverse)
@@ -624,14 +624,14 @@ class TestAugmentations:
         np.testing.assert_almost_equal(results['lq'][1], img_lq2)
         np.testing.assert_almost_equal(results['gt'][0], img_gt)
 
-    def mirror_extend(self):
+    def mirror_sequence_extend(self):
         lqs = [np.random.rand(4, 4, 3) for _ in range(0, 5)]
         gts = [np.random.rand(16, 16, 3) for _ in range(0, 5)]
 
         target_keys = ['lq', 'gt']
-        mirror_extend = MirrorExtend(keys=['lq', 'gt'])
+        mirror_sequence_extend = MirrorSequenceExtend(keys=['lq', 'gt'])
         results = dict(lq=lqs, gt=gts)
-        results = mirror_extend(results)
+        results = mirror_sequence_extend(results)
 
         assert self.check_keys_contain(results.keys(), target_keys)
         for i in range(0, 5):
@@ -640,10 +640,11 @@ class TestAugmentations:
             np.testing.assert_almost_equal(results['gt'][i],
                                            results['gt'][-i - 1])
 
-        assert repr(mirror_extend) == mirror_extend.__class__.__name__ + (
-            f"(keys=['lq', 'gt'])")
+        assert repr(mirror_sequence_extend
+                    ) == mirror_sequence_extend.__class__.__name__ + (
+                        f"(keys=['lq', 'gt'])")
 
         # each key should contain a list of nparray
         with pytest.raises(TypeError):
             results = dict(lq=0, gt=gts)
-            mirror_extend(results)
+            mirror_sequence_extend(results)

--- a/tests/test_augmentation.py
+++ b/tests/test_augmentation.py
@@ -7,10 +7,11 @@ import torch
 # yapf: disable
 from mmedit.datasets.pipelines import (BinarizeImage, Flip,
                                        GenerateFrameIndices,
-                                       GenerateFrameIndiceswithPadding, Pad,
-                                       RandomAffine, RandomJitter,
-                                       RandomMaskDilation, RandomTransposeHW,
-                                       Resize, TemporalReverse)
+                                       GenerateFrameIndiceswithPadding,
+                                       MirrorExtend, Pad, RandomAffine,
+                                       RandomJitter, RandomMaskDilation,
+                                       RandomTransposeHW, Resize,
+                                       TemporalReverse)
 
 # yapf: enable
 
@@ -622,3 +623,27 @@ class TestAugmentations:
         np.testing.assert_almost_equal(results['lq'][0], img_lq1)
         np.testing.assert_almost_equal(results['lq'][1], img_lq2)
         np.testing.assert_almost_equal(results['gt'][0], img_gt)
+
+    def mirror_extend(self):
+        lqs = [np.random.rand(4, 4, 3) for _ in range(0, 5)]
+        gts = [np.random.rand(16, 16, 3) for _ in range(0, 5)]
+
+        target_keys = ['lq', 'gt']
+        mirror_extend = MirrorExtend(keys=['lq', 'gt'])
+        results = dict(lq=lqs, gt=gts)
+        results = mirror_extend(results)
+
+        assert self.check_keys_contain(results.keys(), target_keys)
+        for i in range(0, 5):
+            np.testing.assert_almost_equal(results['lq'][i],
+                                           results['lq'][-i - 1])
+            np.testing.assert_almost_equal(results['gt'][i],
+                                           results['gt'][-i - 1])
+
+        assert repr(mirror_extend) == mirror_extend.__class__.__name__ + (
+            f"(keys=['lq', 'gt'])")
+
+        # each key should contain a list of nparray
+        with pytest.raises(TypeError):
+            results = dict(lq=0, gt=gts)
+            mirror_extend(results)

--- a/tests/test_augmentation.py
+++ b/tests/test_augmentation.py
@@ -8,7 +8,7 @@ import torch
 from mmedit.datasets.pipelines import (BinarizeImage, Flip,
                                        GenerateFrameIndices,
                                        GenerateFrameIndiceswithPadding,
-                                       MirrorSequenceExtend, Pad, RandomAffine,
+                                       MirrorSequence, Pad, RandomAffine,
                                        RandomJitter, RandomMaskDilation,
                                        RandomTransposeHW, Resize,
                                        TemporalReverse)
@@ -624,14 +624,14 @@ class TestAugmentations:
         np.testing.assert_almost_equal(results['lq'][1], img_lq2)
         np.testing.assert_almost_equal(results['gt'][0], img_gt)
 
-    def mirror_sequence_extend(self):
+    def mirror_sequence(self):
         lqs = [np.random.rand(4, 4, 3) for _ in range(0, 5)]
         gts = [np.random.rand(16, 16, 3) for _ in range(0, 5)]
 
         target_keys = ['lq', 'gt']
-        mirror_sequence_extend = MirrorSequenceExtend(keys=['lq', 'gt'])
+        mirror_sequence = MirrorSequence(keys=['lq', 'gt'])
         results = dict(lq=lqs, gt=gts)
-        results = mirror_sequence_extend(results)
+        results = mirror_sequence(results)
 
         assert self.check_keys_contain(results.keys(), target_keys)
         for i in range(0, 5):
@@ -640,11 +640,10 @@ class TestAugmentations:
             np.testing.assert_almost_equal(results['gt'][i],
                                            results['gt'][-i - 1])
 
-        assert repr(mirror_sequence_extend
-                    ) == mirror_sequence_extend.__class__.__name__ + (
-                        f"(keys=['lq', 'gt'])")
+        assert repr(mirror_sequence) == mirror_sequence.__class__.__name__ + (
+            f"(keys=['lq', 'gt'])")
 
         # each key should contain a list of nparray
         with pytest.raises(TypeError):
             results = dict(lq=0, gt=gts)
-            mirror_sequence_extend(results)
+            mirror_sequence(results)


### PR DESCRIPTION
BasicVSR and IconVSR extend the 7-frame Vimeo-90K sequences to 14 frames by mirroring them. This PR adds support to this operation by adding `MirrorExtend`.