### PR TITLE
Add 'GenerateFrameIndicesForRecurrent'

### DIFF
--- a/configs/restorers/basicvsr/basicvsr_reds4.py
+++ b/configs/restorers/basicvsr/basicvsr_reds4.py
@@ -18,7 +18,7 @@ train_dataset_type = 'SRREDSMultipleGTDataset'
 val_dataset_type = 'SRREDSMultipleGTDataset'
 
 train_pipeline = [
-    dict(type='GenerateFrameIndicesForRecurrent', interval_list=[1]),
+    dict(type='GenerateSegmentIndices', interval_list=[1]),
     dict(type='TemporalReverse', keys='lq_path', reverse_ratio=0),
     dict(
         type='LoadImageFromFileList',
@@ -42,7 +42,7 @@ train_pipeline = [
 ]
 
 test_pipeline = [
-    dict(type='GenerateFrameIndicesForRecurrent', interval_list=[1]),
+    dict(type='GenerateSegmentIndices', interval_list=[1]),
     dict(
         type='LoadImageFromFileList',
         io_backend='disk',

--- a/configs/restorers/basicvsr/basicvsr_vimeo90k_bd.py
+++ b/configs/restorers/basicvsr/basicvsr_vimeo90k_bd.py
@@ -42,7 +42,7 @@ train_pipeline = [
 ]
 
 val_pipeline = [
-    dict(type='GenerateFrameIndicesForRecurrent', interval_list=[1]),
+    dict(type='GenerateSegmentIndices', interval_list=[1]),
     dict(
         type='LoadImageFromFileList',
         io_backend='disk',

--- a/configs/restorers/basicvsr/basicvsr_vimeo90k_bi.py
+++ b/configs/restorers/basicvsr/basicvsr_vimeo90k_bi.py
@@ -42,7 +42,7 @@ train_pipeline = [
 ]
 
 val_pipeline = [
-    dict(type='GenerateFrameIndicesForRecurrent', interval_list=[1]),
+    dict(type='GenerateSegmentIndices', interval_list=[1]),
     dict(
         type='LoadImageFromFileList',
         io_backend='disk',

--- a/mmedit/datasets/pipelines/__init__.py
+++ b/mmedit/datasets/pipelines/__init__.py
@@ -1,7 +1,7 @@
 from .augmentation import (BinarizeImage, Flip, GenerateFrameIndices,
-                           GenerateFrameIndicesForRecurrent,
-                           GenerateFrameIndiceswithPadding, MirrorSequence,
-                           Pad, RandomAffine, RandomJitter, RandomMaskDilation,
+                           GenerateFrameIndiceswithPadding,
+                           GenerateSegmentIndices, MirrorSequence, Pad,
+                           RandomAffine, RandomJitter, RandomMaskDilation,
                            RandomTransposeHW, Resize, TemporalReverse)
 from .compose import Compose
 from .crop import (Crop, CropAroundCenter, CropAroundFg, CropAroundUnknown,
@@ -30,6 +30,5 @@ __all__ = [
     'LoadPairedImageFromFile', 'GenerateSoftSeg', 'GenerateSeg', 'PerturbBg',
     'CropAroundFg', 'GetSpatialDiscountMask', 'RandomDownSampling',
     'GenerateTrimapWithDistTransform', 'TransformTrimap',
-    'GenerateCoordinateAndCell', 'GenerateFrameIndicesForRecurrent',
-    'MirrorSequence'
+    'GenerateCoordinateAndCell', 'GenerateSegmentIndices', 'MirrorSequence'
 ]

--- a/mmedit/datasets/pipelines/__init__.py
+++ b/mmedit/datasets/pipelines/__init__.py
@@ -1,4 +1,5 @@
 from .augmentation import (BinarizeImage, Flip, GenerateFrameIndices,
+                           GenerateFrameIndicesForRecurrent,
                            GenerateFrameIndiceswithPadding, MirrorSequence,
                            Pad, RandomAffine, RandomJitter, RandomMaskDilation,
                            RandomTransposeHW, Resize, TemporalReverse)
@@ -29,5 +30,6 @@ __all__ = [
     'LoadPairedImageFromFile', 'GenerateSoftSeg', 'GenerateSeg', 'PerturbBg',
     'CropAroundFg', 'GetSpatialDiscountMask', 'RandomDownSampling',
     'GenerateTrimapWithDistTransform', 'TransformTrimap',
-    'GenerateCoordinateAndCell', 'MirrorSequence'
+    'GenerateCoordinateAndCell', 'GenerateFrameIndicesForRecurrent',
+    'MirrorSequence'
 ]

--- a/mmedit/datasets/pipelines/augmentation.py
+++ b/mmedit/datasets/pipelines/augmentation.py
@@ -899,8 +899,8 @@ class TemporalReverse:
 
 @PIPELINES.register_module()
 class GenerateSegmentIndices:
-    """Generate frame index for training recurrent networks. It also performs
-    temporal augmention with random interval.
+    """Generate frame indices for a segment. It also performs temporal
+    augmention with random interval.
 
     Required keys: lq_path, gt_path, key, num_input_frames, sequence_length
     Added or modified keys:  lq_path, gt_path, interval, reverse

--- a/mmedit/datasets/pipelines/augmentation.py
+++ b/mmedit/datasets/pipelines/augmentation.py
@@ -898,7 +898,7 @@ class TemporalReverse:
 
 
 @PIPELINES.register_module()
-class GenerateFrameIndicesForRecurrent:
+class GenerateSegmentIndices:
     """Generate frame index for training recurrent networks. It also performs
     temporal augmention with random interval.
 

--- a/mmedit/datasets/pipelines/augmentation.py
+++ b/mmedit/datasets/pipelines/augmentation.py
@@ -898,6 +898,75 @@ class TemporalReverse:
 
 
 @PIPELINES.register_module()
+class GenerateFrameIndicesForRecurrent:
+    """Generate frame index for training recurrent networks. It also performs
+    temporal augmention with random interval.
+
+    Required keys: lq_path, gt_path, key, num_input_frames, sequence_length
+    Added or modified keys:  lq_path, gt_path, interval, reverse
+
+    Args:
+        interval_list (list[int]): Interval list for temporal augmentation.
+            It will randomly pick an interval from interval_list and sample
+            frame index with the interval.
+    """
+
+    def __init__(self, interval_list):
+        self.interval_list = interval_list
+
+    def __call__(self, results):
+        """Call function.
+
+        Args:
+            results (dict): A dict containing the necessary information and
+                data for augmentation.
+
+        Returns:
+            dict: A dict containing the processed data and information.
+        """
+        # key example: '000', 'calendar' (sequence name)
+        clip_name = results['key']
+        interval = np.random.choice(self.interval_list)
+
+        self.sequence_length = results['sequence_length']
+        num_input_frames = results.get('num_input_frames',
+                                       self.sequence_length)
+
+        # randomly select a frame as start
+        if self.sequence_length - num_input_frames * interval < 0:
+            raise ValueError('The input sequence is not long enough to '
+                             'support the current choice of [interval] or '
+                             '[num_input_frames].')
+        start_frame_idx = np.random.randint(
+            0, self.sequence_length - num_input_frames * interval + 1)
+        end_frame_idx = start_frame_idx + num_input_frames * interval
+        neighbor_list = list(range(start_frame_idx, end_frame_idx, interval))
+
+        # add the corresponding file paths
+        lq_path_root = results['lq_path']
+        gt_path_root = results['gt_path']
+        lq_path = [
+            osp.join(lq_path_root, clip_name, f'{v:08d}.png')
+            for v in neighbor_list
+        ]
+        gt_path = [
+            osp.join(gt_path_root, clip_name, f'{v:08d}.png')
+            for v in neighbor_list
+        ]
+
+        results['lq_path'] = lq_path
+        results['gt_path'] = gt_path
+        results['interval'] = interval
+
+        return results
+
+    def __repr__(self):
+        repr_str = self.__class__.__name__
+        repr_str += (f'(interval_list={self.interval_list})')
+        return repr_str
+
+
+@PIPELINES.register_module()
 class MirrorSequence:
     """Extend short sequences (e.g. Vimeo-90K) by mirroring the sequences
 

--- a/tests/test_augmentation.py
+++ b/tests/test_augmentation.py
@@ -7,12 +7,11 @@ import torch
 # yapf: disable
 from mmedit.datasets.pipelines import (BinarizeImage, Flip,
                                        GenerateFrameIndices,
-                                       GenerateFrameIndicesForRecurrent,
                                        GenerateFrameIndiceswithPadding,
-                                       MirrorSequence, Pad, RandomAffine,
-                                       RandomJitter, RandomMaskDilation,
-                                       RandomTransposeHW, Resize,
-                                       TemporalReverse)
+                                       GenerateSegmentIndices, MirrorSequence,
+                                       Pad, RandomAffine, RandomJitter,
+                                       RandomMaskDilation, RandomTransposeHW,
+                                       Resize, TemporalReverse)
 
 # yapf: enable
 
@@ -637,8 +636,7 @@ class TestAugmentations:
             'lq_path', 'gt_path', 'key', 'interval', 'num_input_frames',
             'sequence_length'
         ]
-        frame_index_generator = GenerateFrameIndicesForRecurrent(
-            interval_list=[1, 5, 9])
+        frame_index_generator = GenerateSegmentIndices(interval_list=[1, 5, 9])
         rlt = frame_index_generator(copy.deepcopy(results))
         assert self.check_keys_contain(rlt.keys(), target_keys)
 
@@ -654,8 +652,7 @@ class TestAugmentations:
             num_input_frames=11,
             sequence_length=100)
 
-        frame_index_generator = GenerateFrameIndicesForRecurrent(
-            interval_list=[10])
+        frame_index_generator = GenerateSegmentIndices(interval_list=[10])
         with pytest.raises(ValueError):
             frame_index_generator(copy.deepcopy(results))
 

--- a/tests/test_augmentation.py
+++ b/tests/test_augmentation.py
@@ -7,6 +7,7 @@ import torch
 # yapf: disable
 from mmedit.datasets.pipelines import (BinarizeImage, Flip,
                                        GenerateFrameIndices,
+                                       GenerateFrameIndicesForRecurrent,
                                        GenerateFrameIndiceswithPadding,
                                        MirrorSequence, Pad, RandomAffine,
                                        RandomJitter, RandomMaskDilation,
@@ -623,6 +624,40 @@ class TestAugmentations:
         np.testing.assert_almost_equal(results['lq'][0], img_lq1)
         np.testing.assert_almost_equal(results['lq'][1], img_lq2)
         np.testing.assert_almost_equal(results['gt'][0], img_gt)
+
+    def test_frame_index_generation_for_recurrent(self):
+        results = dict(
+            lq_path='fake_lq_root',
+            gt_path='fake_gt_root',
+            key='000',
+            num_input_frames=10,
+            sequence_length=100)
+
+        target_keys = [
+            'lq_path', 'gt_path', 'key', 'interval', 'num_input_frames',
+            'sequence_length'
+        ]
+        frame_index_generator = GenerateFrameIndicesForRecurrent(
+            interval_list=[1, 5, 9])
+        rlt = frame_index_generator(copy.deepcopy(results))
+        assert self.check_keys_contain(rlt.keys(), target_keys)
+
+        name_ = repr(frame_index_generator)
+        assert name_ == frame_index_generator.__class__.__name__ + (
+            '(interval_list=[1, 5, 9])')
+
+        # interval too large
+        results = dict(
+            lq_path='fake_lq_root',
+            gt_path='fake_gt_root',
+            key='000',
+            num_input_frames=11,
+            sequence_length=100)
+
+        frame_index_generator = GenerateFrameIndicesForRecurrent(
+            interval_list=[10])
+        with pytest.raises(ValueError):
+            frame_index_generator(copy.deepcopy(results))
 
     def mirror_sequence(self):
         lqs = [np.random.rand(4, 4, 3) for _ in range(0, 5)]


### PR DESCRIPTION
Add `GenerateFrameIndicesForRecurrent` for randomly picking segments from a video sequence. This is used for training recurrent networks.