### PR TITLE
Tiny fix of `mmedit/apis/test.py`

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -54,5 +54,7 @@ data = dict(
         gt_folder='data/val_set5/Set5_mod12',
         pipeline=test_pipeline,
         scale=scale,
-        filename_tmpl='{}'),
+        filename_tmpl='{}')
+
+empty_cache = True  # empty cache in every iteration.
 ```

--- a/mmedit/apis/test.py
+++ b/mmedit/apis/test.py
@@ -64,7 +64,7 @@ def multi_gpu_test(model,
                    save_image=False,
                    save_path=None,
                    iteration=None,
-                   limited_gpu=False):
+                   empty_cache=False):
     """Test model with multiple gpus.
 
     This method tests model with multiple gpus and collects the results
@@ -83,8 +83,7 @@ def multi_gpu_test(model,
         save_path (str): The path to save image. Default: None.
         iteration (int): Iteration number. It is used for the save image name.
             Default: None.
-        limited_gpu (bool): Limited CUDA memory or not. Default: False.
-            If limited_gpu and not gpu_collect, empty cache in every batch.
+        empty_cache (bool): empty cache in every batch. Default: False.
 
     Returns:
         list: The prediction results.
@@ -108,7 +107,7 @@ def multi_gpu_test(model,
                 iteration=iteration,
                 **data)
         results.append(result)
-        if not gpu_collect and limited_gpu:
+        if empty_cache:
             torch.cuda.empty_cache()
         if rank == 0:
             # get batch size

--- a/mmedit/apis/test.py
+++ b/mmedit/apis/test.py
@@ -105,7 +105,8 @@ def multi_gpu_test(model,
                 iteration=iteration,
                 **data)
         results.append(result)
-
+        if not gpu_collect:
+            torch.cuda.empty_cache()
         if rank == 0:
             # get batch size
             for _, v in data.items():

--- a/mmedit/apis/test.py
+++ b/mmedit/apis/test.py
@@ -83,7 +83,7 @@ def multi_gpu_test(model,
         save_path (str): The path to save image. Default: None.
         iteration (int): Iteration number. It is used for the save image name.
             Default: None.
-        empty_cache (bool): empty cache in every batch. Default: False.
+        empty_cache (bool): empty cache in every iteration. Default: False.
 
     Returns:
         list: The prediction results.

--- a/mmedit/apis/test.py
+++ b/mmedit/apis/test.py
@@ -63,7 +63,8 @@ def multi_gpu_test(model,
                    gpu_collect=False,
                    save_image=False,
                    save_path=None,
-                   iteration=None):
+                   iteration=None,
+                   limited_gpu=False):
     """Test model with multiple gpus.
 
     This method tests model with multiple gpus and collects the results
@@ -82,6 +83,8 @@ def multi_gpu_test(model,
         save_path (str): The path to save image. Default: None.
         iteration (int): Iteration number. It is used for the save image name.
             Default: None.
+        limited_gpu (bool): Limited CUDA memory or not. Default: False.
+            If limited_gpu and not gpu_collect, empty cache in every batch.
 
     Returns:
         list: The prediction results.
@@ -105,7 +108,7 @@ def multi_gpu_test(model,
                 iteration=iteration,
                 **data)
         results.append(result)
-        if not gpu_collect:
+        if not gpu_collect and limited_gpu:
             torch.cuda.empty_cache()
         if rank == 0:
             # get batch size

--- a/tools/test.py
+++ b/tools/test.py
@@ -88,7 +88,7 @@ def main():
     model = build_model(cfg.model, train_cfg=None, test_cfg=cfg.test_cfg)
 
     args.save_image = args.save_path is not None
-    limited_gpu = cfg.limited_gpu is not None and cfg.limited_gpu
+    empty_cache = cfg.empty_cache is not None and cfg.empty_cache
     if not distributed:
         _ = load_checkpoint(model, args.checkpoint, map_location='cpu')
         model = MMDataParallel(model, device_ids=[0])
@@ -117,7 +117,7 @@ def main():
             args.gpu_collect,
             save_path=args.save_path,
             save_image=args.save_image,
-            limited_gpu=limited_gpu)
+            empty_cache=empty_cache)
 
     if rank == 0:
         print('')

--- a/tools/test.py
+++ b/tools/test.py
@@ -88,7 +88,7 @@ def main():
     model = build_model(cfg.model, train_cfg=None, test_cfg=cfg.test_cfg)
 
     args.save_image = args.save_path is not None
-    empty_cache = cfg.empty_cache is not None and cfg.empty_cache
+    empty_cache = cfg.get('empty_cache', False)
     if not distributed:
         _ = load_checkpoint(model, args.checkpoint, map_location='cpu')
         model = MMDataParallel(model, device_ids=[0])

--- a/tools/test.py
+++ b/tools/test.py
@@ -88,6 +88,7 @@ def main():
     model = build_model(cfg.model, train_cfg=None, test_cfg=cfg.test_cfg)
 
     args.save_image = args.save_path is not None
+    limited_gpu = cfg.limited_gpu is not None and cfg.limited_gpu
     if not distributed:
         _ = load_checkpoint(model, args.checkpoint, map_location='cpu')
         model = MMDataParallel(model, device_ids=[0])
@@ -115,7 +116,8 @@ def main():
             args.tmpdir,
             args.gpu_collect,
             save_path=args.save_path,
-            save_image=args.save_image)
+            save_image=args.save_image,
+            limited_gpu=limited_gpu)
 
     if rank == 0:
         print('')


### PR DESCRIPTION
In the current test program (`mmedit/apis/test.py`), the GPU memory occupied by the processed data is not released in time, and `CUDA out of memory ` if the test data is large.
Fix the issue in this PR.