### PR TITLE
Fix `find_unused_parameters` in PyTorch 1.8 for BasicVSR

### DIFF
--- a/configs/restorers/basicvsr/basicvsr_reds4.py
+++ b/configs/restorers/basicvsr/basicvsr_reds4.py
@@ -138,3 +138,4 @@ work_dir = f'./work_dirs/{exp_name}'
 load_from = None
 resume_from = None
 workflow = [('train', 1)]
+find_unused_parameters = True

--- a/configs/restorers/basicvsr/basicvsr_vimeo90k_bd.py
+++ b/configs/restorers/basicvsr/basicvsr_vimeo90k_bd.py
@@ -155,3 +155,4 @@ work_dir = f'./work_dirs/{exp_name}'
 load_from = None
 resume_from = None
 workflow = [('train', 1)]
+find_unused_parameters = True

--- a/configs/restorers/basicvsr/basicvsr_vimeo90k_bi.py
+++ b/configs/restorers/basicvsr/basicvsr_vimeo90k_bi.py
@@ -155,3 +155,4 @@ work_dir = f'./work_dirs/{exp_name}'
 load_from = None
 resume_from = None
 workflow = [('train', 1)]
+find_unused_parameters = True

--- a/configs/restorers/iconvsr/iconvsr_reds4.py
+++ b/configs/restorers/iconvsr/iconvsr_reds4.py
@@ -140,3 +140,4 @@ work_dir = f'./work_dirs/{exp_name}'
 load_from = None
 resume_from = None
 workflow = [('train', 1)]
+find_unused_parameters = True

--- a/configs/restorers/iconvsr/iconvsr_vimeo90k_bd.py
+++ b/configs/restorers/iconvsr/iconvsr_vimeo90k_bd.py
@@ -159,3 +159,4 @@ work_dir = f'./work_dirs/{exp_name}'
 load_from = None
 resume_from = None
 workflow = [('train', 1)]
+find_unused_parameters = True

--- a/configs/restorers/iconvsr/iconvsr_vimeo90k_bi.py
+++ b/configs/restorers/iconvsr/iconvsr_vimeo90k_bi.py
@@ -159,3 +159,4 @@ work_dir = f'./work_dirs/{exp_name}'
 load_from = None
 resume_from = None
 workflow = [('train', 1)]
+find_unused_parameters = True

--- a/mmedit/models/restorers/basicvsr.py
+++ b/mmedit/models/restorers/basicvsr.py
@@ -39,7 +39,7 @@ class BasicVSR(BasicRestorer):
 
         # fix pre-trained networks
         self.fix_iter = train_cfg.get('fix_iter', 0) if train_cfg else 0
-        self.generator.find_unused_parameters = False
+        self.is_weight_fixed = False
 
         # count training steps
         self.register_buffer('step_counter', torch.zeros(1))
@@ -74,14 +74,13 @@ class BasicVSR(BasicRestorer):
         """
         # fix SPyNet and EDVR at the beginning
         if self.step_counter < self.fix_iter:
-            if not self.generator.find_unused_parameters:
-                self.generator.find_unused_parameters = True
+            if not self.is_weight_fixed:
+                self.is_weight_fixed = True
                 for k, v in self.generator.named_parameters():
                     if 'spynet' in k or 'edvr' in k:
                         v.requires_grad_(False)
         elif self.step_counter == self.fix_iter:
             # train all the parameters
-            self.generator.find_unused_parameters = False
             self.generator.requires_grad_(True)
 
         outputs = self(**data_batch, test_mode=False)


### PR DESCRIPTION
As discussed in #273, training of BasicVSR halted due to the settings of `find_unused_parameters`. This PR fixes the error in PyTorch1.8 by removing the modification of  `find_unused_parameters` during training. `find_unused_parameters` is kept `True` throughout training. 