### PR TITLE
Fix error in publish_model.py for pt>=1.6

### DIFF
--- a/tools/publish_model.py
+++ b/tools/publish_model.py
@@ -20,7 +20,10 @@ def process_checkpoint(in_file, out_file):
         del checkpoint['optimizer']
     # if it is necessary to remove some sensitive data in checkpoint['meta'],
     # add the code here.
-    torch.save(checkpoint, out_file)
+    if torch.__version__ >= '1.6':
+        torch.save(checkpoint, out_file, _use_new_zipfile_serialization=False)
+    else:
+        torch.save(checkpoint, out_file)
     sha = subprocess.check_output(['sha256sum', out_file]).decode()
     final_file = out_file.rstrip('.pth') + f'-{sha[:8]}.pth'
     subprocess.Popen(['mv', out_file, final_file])


### PR DESCRIPTION
According to the [official PyTorch docs](https://pytorch.org/docs/stable/generated/torch.save.html)

```
The 1.6 release of PyTorch switched torch.save to use a new zipfile-based file format. torch.load still retains the 
ability to load files in the old format. If for any reason you want torch.save to use the old format, pass the kwarg 
_use_new_zipfile_serialization=False.
```

As a result, when using PyTorch version>=1.6 to publish models, errors occur when loading weights from URL. This PR fixes this error by adding `_use_new_zipfile_serialization=False` for `torch.__version__ >= '1.6'`