### PR TITLE
[Feature] Support FLOPs calculation of video SR models

### DIFF
--- a/tools/get_flops.py
+++ b/tools/get_flops.py
@@ -49,8 +49,10 @@ def main():
     split_line = '=' * 30
     print(f'{split_line}\nInput shape: {input_shape}\n'
           f'Flops: {flops}\nParams: {params}\n{split_line}')
-    print('!!!If you are testing a recurrent network, please divide the '
-          'FLOPs by the number of frames.')
+    if len(input_shape) == 4:
+        print('!!!If your network computes N frames in one forward pass, you '
+              'may want to divide the FLOPs by N to get the average FLOPs '
+              'for each frame.')
     print('!!!Please be cautious if you use the results in papers. '
           'You may need to check if all ops are supported and verify that the '
           'flops computation is correct.')

--- a/tools/get_flops.py
+++ b/tools/get_flops.py
@@ -49,8 +49,8 @@ def main():
     split_line = '=' * 30
     print(f'{split_line}\nInput shape: {input_shape}\n'
           f'Flops: {flops}\nParams: {params}\n{split_line}')
-    print('!!!If you are testing a recurrent network, please make sure to '
-          'divide the FLOPs by the number of frames.')
+    print('!!!If you are testing a recurrent network, please divide the '
+          'FLOPs by the number of frames.')
     print('!!!Please be cautious if you use the results in papers. '
           'You may need to check if all ops are supported and verify that the '
           'flops computation is correct.')

--- a/tools/get_flops.py
+++ b/tools/get_flops.py
@@ -27,7 +27,7 @@ def main():
         input_shape = (3, args.shape[0], args.shape[0])
     elif len(args.shape) == 2:
         input_shape = (3, ) + tuple(args.shape)
-    elif len(args.shape) == 3:
+    elif len(args.shape) in [3, 4]:  # 4 for video inputs (t, c, h, w)
         input_shape = tuple(args.shape)
     else:
         raise ValueError('invalid input shape')
@@ -45,9 +45,12 @@ def main():
             f'with {model.__class__.__name__}')
 
     flops, params = get_model_complexity_info(model, input_shape)
+
     split_line = '=' * 30
     print(f'{split_line}\nInput shape: {input_shape}\n'
           f'Flops: {flops}\nParams: {params}\n{split_line}')
+    print('!!!If you are testing a recurrent network, please make sure to '
+          'divide the FLOPs by the number of frames.')
     print('!!!Please be cautious if you use the results in papers. '
           'You may need to check if all ops are supported and verify that the '
           'flops computation is correct.')


### PR DESCRIPTION
As discussed in #306,  Existing `get_flops.py` does not accept video inputs with size `(t, c, h, w)`. Therefore, the function is not compatible with video SR models such as EDVR, BasicVSR.

This PR adds the support of FLOPs computation of video SR models, by accepting `--shape t c h w`. For example, for BasicVSR, we can compute the FLOPs by using the following command.

```python tools/get_flops.py configs/restorers/basicvsr/basicvsr_vimeo90k_bi.py --shape 5 3 180 320```