### PR TITLE
[Feature] Support 'folder' mode for computing average metric for video SR models

### DIFF
--- a/mmedit/datasets/sr_vid4_dataset.py
+++ b/mmedit/datasets/sr_vid4_dataset.py
@@ -1,3 +1,7 @@
+from collections import defaultdict
+
+import numpy as np
+
 from .base_sr_dataset import BaseSRDataset
 from .registry import DATASETS
 
@@ -33,6 +37,10 @@ class SRVid4Dataset(BaseSRDataset):
         scale (int): Upsampling scale ratio.
         filename_tmpl (str): Template for each filename. Note that the
             template excludes the file extension. Default: '{:08d}'.
+        metric_average_mode (str): The way to compite the average metric.
+            If 'folder', we first compute an average value for each folder, and
+            then average the values from different folders. If 'all', we
+            compute the average of all frames. Default: 'folder'.
         test_mode (bool): Store `True` when building test dataset.
             Default: `False`.
     """
@@ -45,6 +53,7 @@ class SRVid4Dataset(BaseSRDataset):
                  pipeline,
                  scale,
                  filename_tmpl='{:08d}',
+                 metric_average_mode='folder',
                  test_mode=False):
         super().__init__(pipeline, scale, test_mode)
         assert num_input_frames % 2 == 1, (
@@ -55,6 +64,11 @@ class SRVid4Dataset(BaseSRDataset):
         self.ann_file = str(ann_file)
         self.num_input_frames = num_input_frames
         self.filename_tmpl = filename_tmpl
+        if metric_average_mode not in ['folder', 'all']:
+            raise ValueError('metric_average_mode can only be "folder" or '
+                             f'"all", but got {metric_average_mode}.')
+
+        self.metric_average_mode = metric_average_mode
         self.data_infos = self.load_annotations()
 
     def load_annotations(self):
@@ -63,10 +77,13 @@ class SRVid4Dataset(BaseSRDataset):
         Returns:
             dict: Returned dict for LQ and GT pairs.
         """
+        self.folders = {}
         data_infos = []
         with open(self.ann_file, 'r') as fin:
             for line in fin:
                 folder, frame_num, _ = line.strip().split(' ')
+                self.folders[folder] = int(frame_num)
+
                 for i in range(int(frame_num)):
                     data_infos.append(
                         dict(
@@ -76,3 +93,49 @@ class SRVid4Dataset(BaseSRDataset):
                             num_input_frames=self.num_input_frames,
                             max_frame_num=int(frame_num)))
         return data_infos
+
+    def evaluate(self, results, logger=None):
+        """Evaluate with different metrics.
+
+        Args:
+            results (list[tuple]): The output of forward_test() of the model.
+
+        Return:
+            dict: Evaluation results dict.
+        """
+        if not isinstance(results, list):
+            raise TypeError(f'results must be a list, but got {type(results)}')
+        assert len(results) == len(self), (
+            'The length of results is not equal to the dataset len: '
+            f'{len(results)} != {len(self)}')
+
+        results = [res['eval_result'] for res in results]  # a list of dict
+        eval_results = defaultdict(list)  # a dict of list
+
+        for res in results:
+            for metric, val in res.items():
+                eval_results[metric].append(val)
+        for metric, val_list in eval_results.items():
+            assert len(val_list) == len(self), (
+                f'Length of evaluation result of {metric} is {len(val_list)}, '
+                f'should be {len(self)}')
+
+        # average the results
+        if self.metric_average_mode == 'folder':
+            for metric, values in eval_results.items():
+                start_idx = 0
+                metric_avg = 0
+                for _, num_img in self.folders.items():
+                    end_idx = start_idx + num_img
+                    folder_values = values[start_idx:end_idx]
+                    metric_avg += np.mean(folder_values)
+                    start_idx = end_idx
+
+                eval_results[metric] = metric_avg / len(self.folders)
+        else:
+            eval_results = {
+                metric: sum(values) / len(self)
+                for metric, values in eval_results.items()
+            }
+
+        return eval_results

--- a/mmedit/datasets/sr_vid4_dataset.py
+++ b/mmedit/datasets/sr_vid4_dataset.py
@@ -37,10 +37,10 @@ class SRVid4Dataset(BaseSRDataset):
         scale (int): Upsampling scale ratio.
         filename_tmpl (str): Template for each filename. Note that the
             template excludes the file extension. Default: '{:08d}'.
-        metric_average_mode (str): The way to compite the average metric.
-            If 'folder', we first compute an average value for each folder, and
-            then average the values from different folders. If 'all', we
-            compute the average of all frames. Default: 'folder'.
+        metric_average_mode (str): The way to compute the average metric.
+            If 'clip', we first compute an average value for each clip, and
+            then average the values from different clips. If 'all', we
+            compute the average of all frames. Default: 'clip'.
         test_mode (bool): Store `True` when building test dataset.
             Default: `False`.
     """
@@ -53,7 +53,7 @@ class SRVid4Dataset(BaseSRDataset):
                  pipeline,
                  scale,
                  filename_tmpl='{:08d}',
-                 metric_average_mode='folder',
+                 metric_average_mode='clip',
                  test_mode=False):
         super().__init__(pipeline, scale, test_mode)
         assert num_input_frames % 2 == 1, (
@@ -64,8 +64,8 @@ class SRVid4Dataset(BaseSRDataset):
         self.ann_file = str(ann_file)
         self.num_input_frames = num_input_frames
         self.filename_tmpl = filename_tmpl
-        if metric_average_mode not in ['folder', 'all']:
-            raise ValueError('metric_average_mode can only be "folder" or '
+        if metric_average_mode not in ['clip', 'all']:
+            raise ValueError('metric_average_mode can only be "clip" or '
                              f'"all", but got {metric_average_mode}.')
 
         self.metric_average_mode = metric_average_mode
@@ -73,7 +73,6 @@ class SRVid4Dataset(BaseSRDataset):
 
     def load_annotations(self):
         """Load annoations for Vid4 dataset.
-
         Returns:
             dict: Returned dict for LQ and GT pairs.
         """
@@ -96,10 +95,8 @@ class SRVid4Dataset(BaseSRDataset):
 
     def evaluate(self, results, logger=None):
         """Evaluate with different metrics.
-
         Args:
             results (list[tuple]): The output of forward_test() of the model.
-
         Return:
             dict: Evaluation results dict.
         """
@@ -121,7 +118,7 @@ class SRVid4Dataset(BaseSRDataset):
                 f'should be {len(self)}')
 
         # average the results
-        if self.metric_average_mode == 'folder':
+        if self.metric_average_mode == 'clip':
             for metric, values in eval_results.items():
                 start_idx = 0
                 metric_avg = 0

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -897,6 +897,7 @@ def test_vid4_dataset():
             pipeline=[],
             scale=4,
             test_mode=False,
+            metric_average_mode='folder',
             filename_tmpl='{:08d}')
 
         assert vid4_dataset.data_infos == [
@@ -929,6 +930,18 @@ def test_vid4_dataset():
                 num_input_frames=6,
                 pipeline=[],
                 scale=4,
+                test_mode=False)
+
+        with pytest.raises(ValueError):
+            # metric_average_mode can only be either 'folder' or 'all'
+            SRVid4Dataset(
+                lq_folder=root_path,
+                gt_folder=root_path,
+                ann_file='fake_ann_file',
+                num_input_frames=6,
+                pipeline=[],
+                scale=4,
+                metric_average_mode='abc',
                 test_mode=False)
 
 

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -921,6 +921,42 @@ def test_vid4_dataset():
                 max_frame_num=2),
         ]
 
+        # test evaluate function ('folder' mode)
+        results = [{
+            'eval_result': {
+                'PSNR': 21,
+                'SSIM': 0.75
+            }
+        }, {
+            'eval_result': {
+                'PSNR': 22,
+                'SSIM': 0.8
+            }
+        }, {
+            'eval_result': {
+                'PSNR': 24,
+                'SSIM': 0.9
+            }
+        }]
+        eval_results = vid4_dataset.evaluate(results)
+        np.testing.assert_almost_equal(eval_results['PSNR'], 22)
+        np.testing.assert_almost_equal(eval_results['SSIM'], 0.8)
+
+        # test evaluate function ('all' mode)
+        vid4_dataset = SRVid4Dataset(
+            lq_folder=root_path / 'lq',
+            gt_folder=root_path / 'gt',
+            ann_file='fake_ann_file',
+            num_input_frames=5,
+            pipeline=[],
+            scale=4,
+            test_mode=False,
+            metric_average_mode='all',
+            filename_tmpl='{:08d}')
+        eval_results = vid4_dataset.evaluate(results)
+        np.testing.assert_almost_equal(eval_results['PSNR'], 22.3333333)
+        np.testing.assert_almost_equal(eval_results['SSIM'], 0.81666666)
+
         with pytest.raises(AssertionError):
             # num_input_frames should be odd numbers
             SRVid4Dataset(

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -980,6 +980,13 @@ def test_vid4_dataset():
                 metric_average_mode='abc',
                 test_mode=False)
 
+        with pytest.raises(TypeError):
+            # results must be a list
+            vid4_dataset.evaluate(results=5)
+        with pytest.raises(AssertionError):
+            # The length of results should be equal to the dataset len
+            vid4_dataset.evaluate(results=[results[0]])
+
 
 def test_sr_reds_multiple_gt_dataset():
     root_path = Path(__file__).parent / 'data'

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -897,7 +897,7 @@ def test_vid4_dataset():
             pipeline=[],
             scale=4,
             test_mode=False,
-            metric_average_mode='folder',
+            metric_average_mode='clip',
             filename_tmpl='{:08d}')
 
         assert vid4_dataset.data_infos == [
@@ -921,7 +921,7 @@ def test_vid4_dataset():
                 max_frame_num=2),
         ]
 
-        # test evaluate function ('folder' mode)
+        # test evaluate function ('clip' mode)
         results = [{
             'eval_result': {
                 'PSNR': 21,

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -938,7 +938,7 @@ def test_vid4_dataset():
                 lq_folder=root_path,
                 gt_folder=root_path,
                 ann_file='fake_ann_file',
-                num_input_frames=6,
+                num_input_frames=5,
                 pipeline=[],
                 scale=4,
                 metric_average_mode='abc',


### PR DESCRIPTION
When computing quantitative metrics (e.g. PSNR) for video SR, we usually compute the PSNR for each folder first, and then compute the average of the averages". In the existing `SRVid4Dataset`, only the average of all frames is supported. 

This PR adds support of computing the average of averages by adding an argument `metric_average_mode`.