### PR TITLE
Add error message in restoration_demo.py

### DIFF
--- a/demo/restoration_demo.py
+++ b/demo/restoration_demo.py
@@ -1,4 +1,5 @@
 import argparse
+import os
 
 import mmcv
 import torch
@@ -23,7 +24,7 @@ def parse_args():
 def main():
     args = parse_args()
 
-    if not args.img_path.endswith(('.jpg', '.png')):
+    if not os.path.isfile(args.img_path):
         raise ValueError('It seems that you did not input a valid '
                          '"image_path". Please double check your input, or '
                          'you may want to use "restoration_video_demo.py" '

--- a/demo/restoration_demo.py
+++ b/demo/restoration_demo.py
@@ -23,6 +23,12 @@ def parse_args():
 def main():
     args = parse_args()
 
+    if not args.img_path.endswith(('.jpg', '.png')):
+        raise ValueError('It seems that you did not input a valid '
+                         '"image_path". Please double check your input, or '
+                         'you may want to use "restoration_video_demo.py" '
+                         'for video restoration.')
+
     model = init_model(
         args.config, args.checkpoint, device=torch.device('cuda', args.device))
 


### PR DESCRIPTION
## Motivation
There are currently two restoration demos. `restoration_demo.py` is for image restoration, and `restoration_video_demo.py` is for video restoration. These two may be confusing. 

## Modification
In this PR `restoration_demo.py` raises an error if `img_path` does not end with `.png` or `.jpg`. In the error message, we suggest the use of `restoration_video_demo.py` for video restoration.



