### PR TITLE
[Feature] Support different filename templates in GenerateSegmentIndices

### DIFF
--- a/demo/restoration_demo.py
+++ b/demo/restoration_demo.py
@@ -1,4 +1,5 @@
 import argparse
+import os
 
 import mmcv
 import torch
@@ -23,7 +24,7 @@ def parse_args():
 def main():
     args = parse_args()
 
-    if not args.img_path.endswith(('.jpg', '.png')):
+    if not os.path.isfile(args.img_path):
         raise ValueError('It seems that you did not input a valid '
                          '"image_path". Please double check your input, or '
                          'you may want to use "restoration_video_demo.py" '

--- a/demo/restoration_demo.py
+++ b/demo/restoration_demo.py
@@ -23,6 +23,12 @@ def parse_args():
 def main():
     args = parse_args()
 
+    if not args.img_path.endswith(('.jpg', '.png')):
+        raise ValueError('It seems that you did not input a valid '
+                         '"image_path". Please double check your input, or '
+                         'you may want to use "restoration_video_demo.py" '
+                         'for video restoration.')
+
     model = init_model(
         args.config, args.checkpoint, device=torch.device('cuda', args.device))
 

--- a/demo/restoration_video_demo.py
+++ b/demo/restoration_video_demo.py
@@ -14,7 +14,9 @@ def parse_args():
     parser.add_argument('input_dir', help='directory of the input video')
     parser.add_argument('output_dir', help='directory of the output video')
     parser.add_argument(
-        '--filename_tmpl', default='{:08d}', help='template of the file names')
+        '--filename_tmpl',
+        default='{:08d}.png',
+        help='template of the file names')
     parser.add_argument(
         '--window_size',
         type=int,

--- a/demo/restoration_video_demo.py
+++ b/demo/restoration_video_demo.py
@@ -14,6 +14,8 @@ def parse_args():
     parser.add_argument('input_dir', help='directory of the input video')
     parser.add_argument('output_dir', help='directory of the output video')
     parser.add_argument(
+        '--filename_tmpl', default='{:08d}', help='template of the file names')
+    parser.add_argument(
         '--window_size',
         type=int,
         default=0,
@@ -30,7 +32,7 @@ def main():
         args.config, args.checkpoint, device=torch.device('cuda', args.device))
 
     output = restoration_video_inference(model, args.input_dir,
-                                         args.window_size)
+                                         args.window_size, args.filename_tmpl)
     for i in range(0, output.size(1)):
         output_i = output[:, i, :, :, :]
         output_i = tensor2img(output_i)

--- a/mmedit/apis/restoration_video_inference.py
+++ b/mmedit/apis/restoration_video_inference.py
@@ -27,6 +27,7 @@ def restoration_video_inference(model, img_dir, window_size, filename_tmpl):
         window_size (int): The window size used in sliding-window framework.
             This value should be set according to the settings of the network.
             A value smaller than 0 means using recurrent framework.
+
     Returns:
         Tensor: The predicted restoration result.
     """

--- a/mmedit/apis/restoration_video_inference.py
+++ b/mmedit/apis/restoration_video_inference.py
@@ -20,6 +20,7 @@ def pad_sequence(data, window_size):
 
 def restoration_video_inference(model, img_dir, window_size, filename_tmpl):
     """Inference image with the model.
+
     Args:
         model (nn.Module): The loaded model.
         img_dir (str): Directory of the input video.
@@ -29,6 +30,7 @@ def restoration_video_inference(model, img_dir, window_size, filename_tmpl):
     Returns:
         Tensor: The predicted restoration result.
     """
+
     device = next(model.parameters()).device  # model device
 
     # pipeline

--- a/mmedit/apis/restoration_video_inference.py
+++ b/mmedit/apis/restoration_video_inference.py
@@ -18,16 +18,14 @@ def pad_sequence(data, window_size):
     return data
 
 
-def restoration_video_inference(model, img_dir, window_size):
+def restoration_video_inference(model, img_dir, window_size, filename_tmpl):
     """Inference image with the model.
-
     Args:
         model (nn.Module): The loaded model.
         img_dir (str): Directory of the input video.
         window_size (int): The window size used in sliding-window framework.
             This value should be set according to the settings of the network.
             A value smaller than 0 means using recurrent framework.
-
     Returns:
         Tensor: The predicted restoration result.
     """
@@ -35,7 +33,10 @@ def restoration_video_inference(model, img_dir, window_size):
 
     # pipeline
     test_pipeline = [
-        dict(type='GenerateSegmentIndices', interval_list=[1]),
+        dict(
+            type='GenerateSegmentIndices',
+            interval_list=[1],
+            filename_tmpl=filename_tmpl),
         dict(
             type='LoadImageFromFileList',
             io_backend='disk',

--- a/mmedit/datasets/pipelines/augmentation.py
+++ b/mmedit/datasets/pipelines/augmentation.py
@@ -966,12 +966,12 @@ class GenerateSegmentIndices:
         lq_path_root = results['lq_path']
         gt_path_root = results['gt_path']
         lq_path = [
-            osp.join(lq_path_root, clip_name,
-                     f'{self.filename_tmpl.format(v)}') for v in neighbor_list
+            osp.join(lq_path_root, clip_name, self.filename_tmpl.format(v))
+            for v in neighbor_list
         ]
         gt_path = [
-            osp.join(gt_path_root, clip_name,
-                     f'{self.filename_tmpl.format(v)}') for v in neighbor_list
+            osp.join(gt_path_root, clip_name, self.filename_tmpl.format(v))
+            for v in neighbor_list
         ]
 
         results['lq_path'] = lq_path

--- a/mmedit/datasets/pipelines/augmentation.py
+++ b/mmedit/datasets/pipelines/augmentation.py
@@ -927,10 +927,10 @@ class GenerateSegmentIndices:
         interval_list (list[int]): Interval list for temporal augmentation.
             It will randomly pick an interval from interval_list and sample
             frame index with the interval.
-        filename_tmpl (str): Template for file name. Default: '{:08d}'.
+        filename_tmpl (str): Template for file name. Default: '{:08d}.png'.
     """
 
-    def __init__(self, interval_list, filename_tmpl='{:08d}'):
+    def __init__(self, interval_list, filename_tmpl='{:08d}.png'):
         self.interval_list = interval_list
         self.filename_tmpl = filename_tmpl
 
@@ -967,13 +967,11 @@ class GenerateSegmentIndices:
         gt_path_root = results['gt_path']
         lq_path = [
             osp.join(lq_path_root, clip_name,
-                     f'{self.filename_tmpl.format(v)}.png')
-            for v in neighbor_list
+                     f'{self.filename_tmpl.format(v)}') for v in neighbor_list
         ]
         gt_path = [
             osp.join(gt_path_root, clip_name,
-                     f'{self.filename_tmpl.format(v)}.png')
-            for v in neighbor_list
+                     f'{self.filename_tmpl.format(v)}') for v in neighbor_list
         ]
 
         results['lq_path'] = lq_path

--- a/mmedit/datasets/pipelines/augmentation.py
+++ b/mmedit/datasets/pipelines/augmentation.py
@@ -927,10 +927,12 @@ class GenerateSegmentIndices:
         interval_list (list[int]): Interval list for temporal augmentation.
             It will randomly pick an interval from interval_list and sample
             frame index with the interval.
+        filename_tmpl (str): Template for file name. Default: '{:08d}'.
     """
 
-    def __init__(self, interval_list):
+    def __init__(self, interval_list, filename_tmpl='{:08d}'):
         self.interval_list = interval_list
+        self.filename_tmpl = filename_tmpl
 
     def __call__(self, results):
         """Call function.
@@ -964,11 +966,13 @@ class GenerateSegmentIndices:
         lq_path_root = results['lq_path']
         gt_path_root = results['gt_path']
         lq_path = [
-            osp.join(lq_path_root, clip_name, f'{v:08d}.png')
+            osp.join(lq_path_root, clip_name,
+                     f'{self.filename_tmpl.format(v)}.png')
             for v in neighbor_list
         ]
         gt_path = [
-            osp.join(gt_path_root, clip_name, f'{v:08d}.png')
+            osp.join(gt_path_root, clip_name,
+                     f'{self.filename_tmpl.format(v)}.png')
             for v in neighbor_list
         ]
 


### PR DESCRIPTION
## Motivation
As mentioned in issue #323, there will be errors if the file names are not formated as `{v:08d}.png`. This may cause problems if one use custom filename format.

## Modification
In this PR, we modify `GenerateSegmentIndices` so that one can use different filename formats. But note that the frame indices must start from 0.