### PR TITLE
[Feature] Support arbitrary naming in GenerateSegmentIndices

### DIFF
--- a/demo/restoration_video_demo.py
+++ b/demo/restoration_video_demo.py
@@ -14,10 +14,6 @@ def parse_args():
     parser.add_argument('input_dir', help='directory of the input video')
     parser.add_argument('output_dir', help='directory of the output video')
     parser.add_argument(
-        '--filename_tmpl',
-        default='{:08d}.png',
-        help='template of the file names')
-    parser.add_argument(
         '--window_size',
         type=int,
         default=0,
@@ -34,7 +30,7 @@ def main():
         args.config, args.checkpoint, device=torch.device('cuda', args.device))
 
     output = restoration_video_inference(model, args.input_dir,
-                                         args.window_size, args.filename_tmpl)
+                                         args.window_size)
     for i in range(0, output.size(1)):
         output_i = output[:, i, :, :, :]
         output_i = tensor2img(output_i)

--- a/mmedit/apis/restoration_video_inference.py
+++ b/mmedit/apis/restoration_video_inference.py
@@ -18,7 +18,7 @@ def pad_sequence(data, window_size):
     return data
 
 
-def restoration_video_inference(model, img_dir, window_size, filename_tmpl):
+def restoration_video_inference(model, img_dir, window_size):
     """Inference image with the model.
 
     Args:
@@ -36,10 +36,7 @@ def restoration_video_inference(model, img_dir, window_size, filename_tmpl):
 
     # pipeline
     test_pipeline = [
-        dict(
-            type='GenerateSegmentIndices',
-            interval_list=[1],
-            filename_tmpl=filename_tmpl),
+        dict(type='GenerateSegmentIndices', interval_list=[1]),
         dict(
             type='LoadImageFromFileList',
             io_backend='disk',

--- a/mmedit/datasets/pipelines/augmentation.py
+++ b/mmedit/datasets/pipelines/augmentation.py
@@ -927,12 +927,10 @@ class GenerateSegmentIndices:
         interval_list (list[int]): Interval list for temporal augmentation.
             It will randomly pick an interval from interval_list and sample
             frame index with the interval.
-        filename_tmpl (str): Template for file name. Default: '{:08d}.png'.
     """
 
-    def __init__(self, interval_list, filename_tmpl='{:08d}.png'):
+    def __init__(self, interval_list):
         self.interval_list = interval_list
-        self.filename_tmpl = filename_tmpl
 
     def __call__(self, results):
         """Call function.
@@ -965,15 +963,18 @@ class GenerateSegmentIndices:
         # add the corresponding file paths
         lq_path_root = results['lq_path']
         gt_path_root = results['gt_path']
+
+        # retrieve the file names in the directory
+        filenames = sorted(
+            list(mmcv.utils.scandir(osp.join(lq_path_root, clip_name))))
         lq_path = [
-            osp.join(lq_path_root, clip_name, self.filename_tmpl.format(v))
-            for v in neighbor_list
+            osp.join(lq_path_root, clip_name, filenames[i])
+            for i in neighbor_list
         ]
         gt_path = [
-            osp.join(gt_path_root, clip_name, self.filename_tmpl.format(v))
-            for v in neighbor_list
+            osp.join(gt_path_root, clip_name, filenames[i])
+            for i in neighbor_list
         ]
-
         results['lq_path'] = lq_path
         results['gt_path'] = gt_path
         results['interval'] = interval


### PR DESCRIPTION
## Motivation
As mentioned in #335, the existing video_restoration_demo does not support sequences whose start frame index is not 0. This may cause problem in custom video sequences.

## Modification
This PR changes the behavior of the function `GenerateSegmentIndices` so that the image names can now be arbitrary (the latter frames must have larger indices).
1. Instead of assuming the start frame index is 0, `mmcv.utils.scandir` is used to retrieve the filenames.
2. The use of `filename_tmpl` is removed.

In addition, the `video_restoration_inference` is also modified. 