### PR TITLE
Change mmcv minimum version

### DIFF
--- a/mmedit/__init__.py
+++ b/mmedit/__init__.py
@@ -2,7 +2,7 @@ import mmcv
 
 from .version import __version__, version_info
 
-MMCV_MIN = '1.0.2'
+MMCV_MIN = '1.3'
 MMCV_MAX = '1.4'
 
 


### PR DESCRIPTION
## Motivation
As discussed in #376, `_load_checkpoint_with_prefix` is used in StyleGAN, but is not included in `mmcv < 1.3`. 

# Modification
This PR changes the minimum mmcv version specified in `mmedit/__init__.py`, from `1.0.2` to `1.3`.