### PR TITLE
[Fix] Fix normalization in restoration_video_inference

### DIFF
--- a/configs/restorers/basicvsr/basicvsr_reds4.py
+++ b/configs/restorers/basicvsr/basicvsr_reds4.py
@@ -62,6 +62,18 @@ test_pipeline = [
         meta_keys=['lq_path', 'gt_path', 'key'])
 ]
 
+demo_pipeline = [
+    dict(type='GenerateSegmentIndices', interval_list=[1]),
+    dict(
+        type='LoadImageFromFileList',
+        io_backend='disk',
+        key='lq',
+        channel_order='rgb'),
+    dict(type='RescaleToZeroOne', keys=['lq']),
+    dict(type='FramesToTensor', keys=['lq']),
+    dict(type='Collect', keys=['lq'], meta_keys=['lq_path', 'key'])
+]
+
 data = dict(
     workers_per_gpu=6,
     train_dataloader=dict(samples_per_gpu=4, drop_last=True),  # 2 gpus

--- a/configs/restorers/basicvsr/basicvsr_vimeo90k_bd.py
+++ b/configs/restorers/basicvsr/basicvsr_vimeo90k_bd.py
@@ -82,6 +82,18 @@ test_pipeline = [
         meta_keys=['lq_path', 'gt_path', 'key'])
 ]
 
+demo_pipeline = [
+    dict(type='GenerateSegmentIndices', interval_list=[1]),
+    dict(
+        type='LoadImageFromFileList',
+        io_backend='disk',
+        key='lq',
+        channel_order='rgb'),
+    dict(type='RescaleToZeroOne', keys=['lq']),
+    dict(type='FramesToTensor', keys=['lq']),
+    dict(type='Collect', keys=['lq'], meta_keys=['lq_path', 'key'])
+]
+
 data = dict(
     workers_per_gpu=6,
     train_dataloader=dict(samples_per_gpu=4, drop_last=True),  # 2 gpus

--- a/configs/restorers/basicvsr/basicvsr_vimeo90k_bi.py
+++ b/configs/restorers/basicvsr/basicvsr_vimeo90k_bi.py
@@ -62,6 +62,18 @@ val_pipeline = [
         meta_keys=['lq_path', 'gt_path', 'key'])
 ]
 
+demo_pipeline = [
+    dict(type='GenerateSegmentIndices', interval_list=[1]),
+    dict(
+        type='LoadImageFromFileList',
+        io_backend='disk',
+        key='lq',
+        channel_order='rgb'),
+    dict(type='RescaleToZeroOne', keys=['lq']),
+    dict(type='FramesToTensor', keys=['lq']),
+    dict(type='Collect', keys=['lq'], meta_keys=['lq_path', 'key'])
+]
+
 test_pipeline = [
     dict(
         type='LoadImageFromFileList',

--- a/configs/restorers/edvr/edvrm_wotsa_x4_g8_600k_reds.py
+++ b/configs/restorers/edvr/edvrm_wotsa_x4_g8_600k_reds.py
@@ -78,6 +78,18 @@ test_pipeline = [
     dict(type='FramesToTensor', keys=['lq', 'gt'])
 ]
 
+demo_pipeline = [
+    dict(type='GenerateSegmentIndices', interval_list=[1]),
+    dict(
+        type='LoadImageFromFileList',
+        io_backend='disk',
+        key='lq',
+        channel_order='rgb'),
+    dict(type='RescaleToZeroOne', keys=['lq']),
+    dict(type='FramesToTensor', keys=['lq']),
+    dict(type='Collect', keys=['lq'], meta_keys=['lq_path', 'key'])
+]
+
 data = dict(
     workers_per_gpu=4,
     train_dataloader=dict(samples_per_gpu=4, drop_last=True),

--- a/configs/restorers/edvr/edvrm_x4_g8_600k_reds.py
+++ b/configs/restorers/edvr/edvrm_x4_g8_600k_reds.py
@@ -78,6 +78,18 @@ test_pipeline = [
     dict(type='FramesToTensor', keys=['lq', 'gt'])
 ]
 
+demo_pipeline = [
+    dict(type='GenerateSegmentIndices', interval_list=[1]),
+    dict(
+        type='LoadImageFromFileList',
+        io_backend='disk',
+        key='lq',
+        channel_order='rgb'),
+    dict(type='RescaleToZeroOne', keys=['lq']),
+    dict(type='FramesToTensor', keys=['lq']),
+    dict(type='Collect', keys=['lq'], meta_keys=['lq_path', 'key'])
+]
+
 data = dict(
     workers_per_gpu=4,
     train_dataloader=dict(samples_per_gpu=4, drop_last=True),

--- a/configs/restorers/iconvsr/iconvsr_reds4.py
+++ b/configs/restorers/iconvsr/iconvsr_reds4.py
@@ -65,6 +65,18 @@ test_pipeline = [
         meta_keys=['lq_path', 'gt_path', 'key'])
 ]
 
+demo_pipeline = [
+    dict(type='GenerateSegmentIndices', interval_list=[1]),
+    dict(
+        type='LoadImageFromFileList',
+        io_backend='disk',
+        key='lq',
+        channel_order='rgb'),
+    dict(type='RescaleToZeroOne', keys=['lq']),
+    dict(type='FramesToTensor', keys=['lq']),
+    dict(type='Collect', keys=['lq'], meta_keys=['lq_path', 'key'])
+]
+
 data = dict(
     workers_per_gpu=6,
     train_dataloader=dict(samples_per_gpu=4, drop_last=True),

--- a/configs/restorers/iconvsr/iconvsr_vimeo90k_bd.py
+++ b/configs/restorers/iconvsr/iconvsr_vimeo90k_bd.py
@@ -86,6 +86,18 @@ test_pipeline = [
         meta_keys=['lq_path', 'gt_path', 'key'])
 ]
 
+demo_pipeline = [
+    dict(type='GenerateSegmentIndices', interval_list=[1]),
+    dict(
+        type='LoadImageFromFileList',
+        io_backend='disk',
+        key='lq',
+        channel_order='rgb'),
+    dict(type='RescaleToZeroOne', keys=['lq']),
+    dict(type='FramesToTensor', keys=['lq']),
+    dict(type='Collect', keys=['lq'], meta_keys=['lq_path', 'key'])
+]
+
 data = dict(
     workers_per_gpu=6,
     train_dataloader=dict(samples_per_gpu=4, drop_last=True),  # 2 gpus

--- a/configs/restorers/iconvsr/iconvsr_vimeo90k_bi.py
+++ b/configs/restorers/iconvsr/iconvsr_vimeo90k_bi.py
@@ -86,6 +86,18 @@ test_pipeline = [
         meta_keys=['lq_path', 'gt_path', 'key'])
 ]
 
+demo_pipeline = [
+    dict(type='GenerateSegmentIndices', interval_list=[1]),
+    dict(
+        type='LoadImageFromFileList',
+        io_backend='disk',
+        key='lq',
+        channel_order='rgb'),
+    dict(type='RescaleToZeroOne', keys=['lq']),
+    dict(type='FramesToTensor', keys=['lq']),
+    dict(type='Collect', keys=['lq'], meta_keys=['lq_path', 'key'])
+]
+
 data = dict(
     workers_per_gpu=6,
     train_dataloader=dict(samples_per_gpu=4, drop_last=True),  # 2 gpus

--- a/configs/restorers/tdan/tdan_vimeo90k_bdx4_ft_lr5e-5_800k.py
+++ b/configs/restorers/tdan/tdan_vimeo90k_bdx4_ft_lr5e-5_800k.py
@@ -63,6 +63,19 @@ val_pipeline = [
     dict(type='Collect', keys=['lq', 'gt'], meta_keys=['lq_path', 'gt_path'])
 ]
 
+demo_pipeline = [
+    dict(type='GenerateSegmentIndices', interval_list=[1]),
+    dict(
+        type='LoadImageFromFileList',
+        io_backend='disk',
+        key='lq',
+        channel_order='rgb'),
+    dict(type='RescaleToZeroOne', keys=['lq']),
+    dict(type='Normalize', keys=['lq'], mean=[0.5, 0.5, 0.5], std=[1, 1, 1]),
+    dict(type='FramesToTensor', keys=['lq']),
+    dict(type='Collect', keys=['lq'], meta_keys=['lq_path', 'key'])
+]
+
 data = dict(
     workers_per_gpu=8,
     train_dataloader=dict(samples_per_gpu=16, drop_last=True),  # 8 gpus

--- a/configs/restorers/tdan/tdan_vimeo90k_bdx4_lr1e-4_400k.py
+++ b/configs/restorers/tdan/tdan_vimeo90k_bdx4_lr1e-4_400k.py
@@ -63,6 +63,19 @@ val_pipeline = [
     dict(type='Collect', keys=['lq', 'gt'], meta_keys=['lq_path', 'gt_path'])
 ]
 
+demo_pipeline = [
+    dict(type='GenerateSegmentIndices', interval_list=[1]),
+    dict(
+        type='LoadImageFromFileList',
+        io_backend='disk',
+        key='lq',
+        channel_order='rgb'),
+    dict(type='RescaleToZeroOne', keys=['lq']),
+    dict(type='Normalize', keys=['lq'], mean=[0.5, 0.5, 0.5], std=[1, 1, 1]),
+    dict(type='FramesToTensor', keys=['lq']),
+    dict(type='Collect', keys=['lq'], meta_keys=['lq_path', 'key'])
+]
+
 data = dict(
     workers_per_gpu=8,
     train_dataloader=dict(samples_per_gpu=16, drop_last=True),  # 8 gpus

--- a/configs/restorers/tdan/tdan_vimeo90k_bix4_ft_lr5e-5_400k.py
+++ b/configs/restorers/tdan/tdan_vimeo90k_bix4_ft_lr5e-5_400k.py
@@ -63,6 +63,19 @@ val_pipeline = [
     dict(type='Collect', keys=['lq', 'gt'], meta_keys=['lq_path', 'gt_path'])
 ]
 
+demo_pipeline = [
+    dict(type='GenerateSegmentIndices', interval_list=[1]),
+    dict(
+        type='LoadImageFromFileList',
+        io_backend='disk',
+        key='lq',
+        channel_order='rgb'),
+    dict(type='RescaleToZeroOne', keys=['lq']),
+    dict(type='Normalize', keys=['lq'], mean=[0.5, 0.5, 0.5], std=[1, 1, 1]),
+    dict(type='FramesToTensor', keys=['lq']),
+    dict(type='Collect', keys=['lq'], meta_keys=['lq_path', 'key'])
+]
+
 data = dict(
     workers_per_gpu=8,
     train_dataloader=dict(samples_per_gpu=16, drop_last=True),  # 8 gpus

--- a/configs/restorers/tdan/tdan_vimeo90k_bix4_lr1e-4_400k.py
+++ b/configs/restorers/tdan/tdan_vimeo90k_bix4_lr1e-4_400k.py
@@ -63,6 +63,19 @@ val_pipeline = [
     dict(type='Collect', keys=['lq', 'gt'], meta_keys=['lq_path', 'gt_path'])
 ]
 
+demo_pipeline = [
+    dict(type='GenerateSegmentIndices', interval_list=[1]),
+    dict(
+        type='LoadImageFromFileList',
+        io_backend='disk',
+        key='lq',
+        channel_order='rgb'),
+    dict(type='RescaleToZeroOne', keys=['lq']),
+    dict(type='Normalize', keys=['lq'], mean=[0.5, 0.5, 0.5], std=[1, 1, 1]),
+    dict(type='FramesToTensor', keys=['lq']),
+    dict(type='Collect', keys=['lq'], meta_keys=['lq_path', 'key'])
+]
+
 data = dict(
     workers_per_gpu=8,
     train_dataloader=dict(samples_per_gpu=16, drop_last=True),  # 8 gpus

--- a/configs/restorers/tof/tof_x4_vimeo90k_official.py
+++ b/configs/restorers/tof/tof_x4_vimeo90k_official.py
@@ -39,6 +39,18 @@ test_pipeline = [
     dict(type='FramesToTensor', keys=['lq', 'gt'])
 ]
 
+demo_pipeline = [
+    dict(type='GenerateSegmentIndices', interval_list=[1]),
+    dict(
+        type='LoadImageFromFileList',
+        io_backend='disk',
+        key='lq',
+        channel_order='rgb'),
+    dict(type='RescaleToZeroOne', keys=['lq']),
+    dict(type='FramesToTensor', keys=['lq']),
+    dict(type='Collect', keys=['lq'], meta_keys=['lq_path', 'key'])
+]
+
 data = dict(
     workers_per_gpu=8,
     test=dict(

--- a/demo/restoration_video_demo.py
+++ b/demo/restoration_video_demo.py
@@ -41,10 +41,12 @@ def main():
     output = restoration_video_inference(model, args.input_dir,
                                          args.window_size, args.start_idx,
                                          args.filename_tmpl)
-    for i in range(0, output.size(1)):
-        output_i = output[:, i, :, :, :]
+    args.start_idx = 1
+    args.filename_tmpl = '{:03d}.png'
+    for i in range(args.start_idx, args.start_idx + output.size(1)):
+        output_i = output[:, i - args.start_idx, :, :, :]
         output_i = tensor2img(output_i)
-        save_path_i = f'{args.output_dir}/{i:08d}.png'
+        save_path_i = f'{args.output_dir}/{args.filename_tmpl.format(i)}'
 
         mmcv.imwrite(output_i, save_path_i)
 

--- a/mmedit/apis/restoration_video_inference.py
+++ b/mmedit/apis/restoration_video_inference.py
@@ -38,35 +38,8 @@ def restoration_video_inference(model, img_dir, window_size, start_idx,
 
     device = next(model.parameters()).device  # model device
 
-    # pipeline
-    test_pipeline = [
-        dict(
-            type='GenerateSegmentIndices',
-            interval_list=[1],
-            start_idx=start_idx,
-            filename_tmpl=filename_tmpl),
-        dict(
-            type='LoadImageFromFileList',
-            io_backend='disk',
-            key='lq',
-            channel_order='rgb'),
-        dict(type='RescaleToZeroOne', keys=['lq']),
-    ]
-
-    # add normalize if it is used in the model
-    for op in model.cfg.train_pipeline:
-        if op['type'] == 'Normalize':
-            if 'gt' in op['keys']:  # remove 'gt' in keys
-                op['keys'].remove('gt')
-            test_pipeline.append(op)
-
-    test_pipeline.extend([
-        dict(type='FramesToTensor', keys=['lq']),
-        dict(type='Collect', keys=['lq'], meta_keys=['lq_path', 'key'])
-    ])
-
     # build the data pipeline
-    test_pipeline = Compose(test_pipeline)
+    test_pipeline = Compose(model.cfg.demo_pipeline)
 
     # prepare data
     sequence_length = len(glob.glob(f'{img_dir}/*'))

--- a/mmedit/apis/restoration_video_inference.py
+++ b/mmedit/apis/restoration_video_inference.py
@@ -51,9 +51,19 @@ def restoration_video_inference(model, img_dir, window_size, start_idx,
             key='lq',
             channel_order='rgb'),
         dict(type='RescaleToZeroOne', keys=['lq']),
+    ]
+
+    # add normalize if it is used in the model
+    for op in model.cfg.train_pipeline:
+        if op['type'] == 'Normalize':
+            if 'gt' in op['keys']:  # remove 'gt' in keys
+                op['keys'].remove('gt')
+            test_pipeline.append(op)
+
+    test_pipeline.extend([
         dict(type='FramesToTensor', keys=['lq']),
         dict(type='Collect', keys=['lq'], meta_keys=['lq_path', 'key'])
-    ]
+    ])
 
     # build the data pipeline
     test_pipeline = Compose(test_pipeline)

--- a/mmedit/core/mask.py
+++ b/mmedit/core/mask.py
@@ -202,8 +202,7 @@ def brush_stroke_mask(img_shape,
     if np.random.normal() > 0:
         mask.transpose(Image.FLIP_TOP_BOTTOM)
 
-    # mask = np.asarray(mask, dtype=np.uint8)
-    mask = np.array(mask)
+    mask = np.array(mask).astype(dtype=getattr(np, dtype))
     mask = mask[:, :, None]
     return mask
 

--- a/mmedit/core/mask.py
+++ b/mmedit/core/mask.py
@@ -201,7 +201,9 @@ def brush_stroke_mask(img_shape,
         mask.transpose(Image.FLIP_LEFT_RIGHT)
     if np.random.normal() > 0:
         mask.transpose(Image.FLIP_TOP_BOTTOM)
-    mask = np.asarray(mask, dtype=np.uint8)
+
+    # mask = np.asarray(mask, dtype=np.uint8)
+    mask = np.array(mask)
     mask = mask[:, :, None]
     return mask
 

--- a/mmedit/core/mask.py
+++ b/mmedit/core/mask.py
@@ -201,7 +201,7 @@ def brush_stroke_mask(img_shape,
         mask.transpose(Image.FLIP_LEFT_RIGHT)
     if np.random.normal() > 0:
         mask.transpose(Image.FLIP_TOP_BOTTOM)
-    mask = np.asarray(mask, dtype=getattr(np, dtype))
+    mask = np.asarray(mask, dtype=np.uint8)
     mask = mask[:, :, None]
     return mask
 


### PR DESCRIPTION
## Motivation
Most of the video SR models in MMEditing take inputs with range [0, 1], but TDAN takes inputs with range [-0.5, 0.5]. Therefore, `Normalize` should be added to the pipeline in `restoration_video_inference.py`.

## Modification
`demo_pipeline` is added in the configuration files of each VSR model. The demo will look for `demo_pipeline`.

## Remark
An additional modification is that the output images are named according to `args.filename_tmpl` and `args.start_idx`.