### PR TITLE
[Feature] Support loading annotation from file for video SR datasets

### DIFF
--- a/mmedit/datasets/sr_folder_multiple_gt_dataset.py
+++ b/mmedit/datasets/sr_folder_multiple_gt_dataset.py
@@ -1,6 +1,8 @@
 import glob
 import os.path as osp
 
+import mmcv
+
 from .base_sr_dataset import BaseSRDataset
 from .registry import DATASETS
 
@@ -70,20 +72,20 @@ class SRFolderMultipleGTDataset(BaseSRDataset):
     def _load_annotations_from_file(self):
         data_infos = []
 
-        with open(self.ann_file, 'r') as fin:
-            for line in fin:
-                key, sequence_length = line.strip().split(' ')
-                if self.num_input_frames is None:
-                    num_input_frames = sequence_length
-                else:
-                    num_input_frames = self.num_input_frames
-                data_infos.append(
-                    dict(
-                        lq_path=self.lq_folder,
-                        gt_path=self.gt_folder,
-                        key=key,
-                        num_input_frames=int(num_input_frames),
-                        sequence_length=int(sequence_length)))
+        ann_list = mmcv.list_from_file(self.ann_file)
+        for ann in ann_list:
+            key, sequence_length = ann.strip().split(' ')
+            if self.num_input_frames is None:
+                num_input_frames = sequence_length
+            else:
+                num_input_frames = self.num_input_frames
+            data_infos.append(
+                dict(
+                    lq_path=self.lq_folder,
+                    gt_path=self.gt_folder,
+                    key=key,
+                    num_input_frames=int(num_input_frames),
+                    sequence_length=int(sequence_length)))
 
         return data_infos
 

--- a/mmedit/datasets/sr_folder_multiple_gt_dataset.py
+++ b/mmedit/datasets/sr_folder_multiple_gt_dataset.py
@@ -9,18 +9,35 @@ from .registry import DATASETS
 class SRFolderMultipleGTDataset(BaseSRDataset):
     """General dataset for video super resolution, used for recurrent networks.
 
-    It assumes all video clips under the root directory is used for training
-    or test.
-
     The dataset loads several LQ (Low-Quality) frames and GT (Ground-Truth)
     frames. Then it applies specified transforms and finally returns a dict
     containing paired data and other information.
+
+    This dataset takes an annotation file specifying the sequences used in
+    training or test. If no annotation file is provided, it assumes all video
+    sequences under the root directory is used for training or test.
+
+    In the annotation file (.txt), each line contains:
+
+        1. folder name;
+        2. number of frames in this sequence (in the same folder)
+
+    Examples:
+
+    ::
+
+        calendar 41
+        city 34
+        foliage 49
+        walk 47
 
     Args:
         lq_folder (str | :obj:`Path`): Path to a lq folder.
         gt_folder (str | :obj:`Path`): Path to a gt folder.
         pipeline (list[dict | callable]): A sequence of data transformations.
         scale (int): Upsampling scale ratio.
+        ann_file (str): The path to the annotation file. If None, we assume
+            that all sequences in the folder is used. Default: None
         num_input_frames (None | int): The number of frames per iteration.
             If None, the whole clip is extracted. If it is a positive integer,
             a sequence of 'num_input_frames' frames is extracted from the clip.
@@ -34,12 +51,14 @@ class SRFolderMultipleGTDataset(BaseSRDataset):
                  gt_folder,
                  pipeline,
                  scale,
+                 ann_file=None,
                  num_input_frames=None,
                  test_mode=True):
         super().__init__(pipeline, scale, test_mode)
 
         self.lq_folder = str(lq_folder)
         self.gt_folder = str(gt_folder)
+        self.ann_file = ann_file
 
         if num_input_frames is not None and num_input_frames <= 0:
             raise ValueError('"num_input_frames" must be None or positive, '
@@ -48,12 +67,35 @@ class SRFolderMultipleGTDataset(BaseSRDataset):
 
         self.data_infos = self.load_annotations()
 
+    def _load_annotations_from_file(self):
+        data_infos = []
+
+        with open(self.ann_file, 'r') as fin:
+            for line in fin:
+                key, sequence_length = line.strip().split(' ')
+                if self.num_input_frames is None:
+                    num_input_frames = sequence_length
+                else:
+                    num_input_frames = self.num_input_frames
+                data_infos.append(
+                    dict(
+                        lq_path=self.lq_folder,
+                        gt_path=self.gt_folder,
+                        key=key,
+                        num_input_frames=int(num_input_frames),
+                        sequence_length=int(sequence_length)))
+
+        return data_infos
+
     def load_annotations(self):
         """Load annoations for the dataset.
 
         Returns:
             dict: Returned dict for LQ and GT pairs.
         """
+
+        if self.ann_file:
+            return self._load_annotations_from_file()
 
         sequences = sorted(glob.glob(osp.join(self.lq_folder, '*')))
         data_infos = []

--- a/mmedit/datasets/sr_folder_video_dataset.py
+++ b/mmedit/datasets/sr_folder_video_dataset.py
@@ -88,20 +88,20 @@ class SRFolderVideoDataset(BaseSRDataset):
         self.folders = {}
         data_infos = []
 
-        with open(self.ann_file, 'r') as fin:
-            for line in fin:
-                key, max_frame_num = line.strip().split(' ')
-                sequence = key.split('/')[0]
-                if sequence not in self.folders:
-                    self.folders[sequence] = int(max_frame_num)
+        ann_list = mmcv.list_from_file(self.ann_file)
+        for ann in ann_list:
+            key, max_frame_num = ann.strip().rsplit(' ', 1)
+            sequence = osp.basename(key)
+            if sequence not in self.folders:
+                self.folders[sequence] = int(max_frame_num)
 
-                data_infos.append(
-                    dict(
-                        lq_path=self.lq_folder,
-                        gt_path=self.gt_folder,
-                        key=key,
-                        num_input_frames=self.num_input_frames,
-                        max_frame_num=int(max_frame_num)))
+            data_infos.append(
+                dict(
+                    lq_path=self.lq_folder,
+                    gt_path=self.gt_folder,
+                    key=key,
+                    num_input_frames=self.num_input_frames,
+                    max_frame_num=int(max_frame_num)))
 
         return data_infos
 

--- a/mmedit/datasets/sr_folder_video_dataset.py
+++ b/mmedit/datasets/sr_folder_video_dataset.py
@@ -13,12 +13,30 @@ from .registry import DATASETS
 class SRFolderVideoDataset(BaseSRDataset):
     """General dataset for video SR, used for sliding-window framework.
 
-    It assumes all video sequences under the root directory are used for
-    training or test.
-
     The dataset loads several LQ (Low-Quality) frames and one GT (Ground-Truth)
     frames. Then it applies specified transforms and finally returns a dict
     containing paired data and other information.
+
+    This dataset takes an annotation file specifying the sequences used in
+    training or test. If no annotation file is provided, it assumes all video
+    sequences under the root directory are used for training or test.
+
+    In the annotation file (.txt), each line contains:
+
+        1. image name (no file extension);
+        2. number of frames in the sequence (in the same folder)
+
+    Examples:
+
+    ::
+
+        calendar/00000000 41
+        calendar/00000001 41
+        ...
+        calendar/00000040 41
+        city/00000000 34
+        ...
+
 
     Args:
         lq_folder (str | :obj:`Path`): Path to a lq folder.
@@ -26,6 +44,8 @@ class SRFolderVideoDataset(BaseSRDataset):
         num_input_frames (int): Window size for input frames.
         pipeline (list[dict | callable]): A sequence of data transformations.
         scale (int): Upsampling scale ratio.
+        ann_file (str): The path to the annotation file. If None, we assume
+            that all sequences in the folder is used. Default: None.
         filename_tmpl (str): Template for each filename. Note that the
             template excludes the file extension. Default: '{:08d}'.
         metric_average_mode (str): The way to compute the average metric.
@@ -42,6 +62,7 @@ class SRFolderVideoDataset(BaseSRDataset):
                  num_input_frames,
                  pipeline,
                  scale,
+                 ann_file=None,
                  filename_tmpl='{:08d}',
                  metric_average_mode='clip',
                  test_mode=True):
@@ -57,10 +78,32 @@ class SRFolderVideoDataset(BaseSRDataset):
         self.lq_folder = str(lq_folder)
         self.gt_folder = str(gt_folder)
         self.num_input_frames = num_input_frames
+        self.ann_file = ann_file
         self.filename_tmpl = filename_tmpl
         self.metric_average_mode = metric_average_mode
 
         self.data_infos = self.load_annotations()
+
+    def _load_annotations_from_file(self):
+        self.folders = {}
+        data_infos = []
+
+        with open(self.ann_file, 'r') as fin:
+            for line in fin:
+                key, max_frame_num = line.strip().split(' ')
+                sequence = key.split('/')[0]
+                if sequence not in self.folders:
+                    self.folders[sequence] = int(max_frame_num)
+
+                data_infos.append(
+                    dict(
+                        lq_path=self.lq_folder,
+                        gt_path=self.gt_folder,
+                        key=key,
+                        num_input_frames=self.num_input_frames,
+                        max_frame_num=int(max_frame_num)))
+
+        return data_infos
 
     def load_annotations(self):
         """Load annoations for the dataset.
@@ -68,6 +111,9 @@ class SRFolderVideoDataset(BaseSRDataset):
         Returns:
             dict: Returned dict for LQ and GT pairs.
         """
+
+        if self.ann_file:
+            return self._load_annotations_from_file()
 
         self.folders = {}
         data_infos = []

--- a/mmedit/datasets/sr_vimeo90k_multiple_gt_dataset.py
+++ b/mmedit/datasets/sr_vimeo90k_multiple_gt_dataset.py
@@ -30,17 +30,26 @@ class SRVimeo90KMultipleGTDataset(BaseSRDataset):
         ann_file (str | :obj:`Path`): Path to the annotation file.
         pipeline (list[dict | callable]): A sequence of data transformations.
         scale (int): Upsampling scale ratio.
+       num_input_frames (int): Number of frames in each training sequence.
+            Default: 7.
         test_mode (bool): Store `True` when building test dataset.
             Default: `False`.
     """
 
-    def __init__(self, lq_folder, gt_folder, ann_file, pipeline, scale,
-                 test_mode):
+    def __init__(self,
+                 lq_folder,
+                 gt_folder,
+                 ann_file,
+                 pipeline,
+                 scale,
+                 num_input_frames=7,
+                 test_mode=False):
         super().__init__(pipeline, scale, test_mode)
 
         self.lq_folder = str(lq_folder)
         self.gt_folder = str(gt_folder)
         self.ann_file = str(ann_file)
+        self.num_input_frames = num_input_frames
 
         self.data_infos = self.load_annotations()
 
@@ -58,11 +67,11 @@ class SRVimeo90KMultipleGTDataset(BaseSRDataset):
         for key in keys:
             lq_paths = [
                 osp.join(self.lq_folder, key, f'im{i}.png')
-                for i in range(1, 8)
+                for i in range(1, self.num_input_frames + 1)
             ]
             gt_paths = [
                 osp.join(self.gt_folder, key, f'im{i}.png')
-                for i in range(1, 8)
+                for i in range(1, self.num_input_frames + 1)
             ]
 
             data_infos.append(

--- a/mmedit/datasets/sr_vimeo90k_multiple_gt_dataset.py
+++ b/mmedit/datasets/sr_vimeo90k_multiple_gt_dataset.py
@@ -1,4 +1,3 @@
-import glob
 import os.path as osp
 
 from .base_sr_dataset import BaseSRDataset
@@ -57,10 +56,14 @@ class SRVimeo90KMultipleGTDataset(BaseSRDataset):
 
         data_infos = []
         for key in keys:
-            lq_paths = sorted(
-                glob.glob(osp.join(self.lq_folder, key, '*.png')))
-            gt_paths = sorted(
-                glob.glob(osp.join(self.gt_folder, key, '*.png')))
+            lq_paths = [
+                osp.join(self.lq_folder, key, f'im{i}.png')
+                for i in range(1, 8)
+            ]
+            gt_paths = [
+                osp.join(self.gt_folder, key, f'im{i}.png')
+                for i in range(1, 8)
+            ]
 
             data_infos.append(
                 dict(lq_path=lq_paths, gt_path=gt_paths, key=key))

--- a/tests/test_data/test_datasets/test_sr_dataset.py
+++ b/tests/test_data/test_datasets/test_sr_dataset.py
@@ -793,11 +793,15 @@ def test_sr_vimeo90k_mutiple_gt_dataset():
 
     txt_content = ('00001/0266 (256,448,3)\n')
     mocked_open_function = mock_open(read_data=txt_content)
+
+    num_input_frames = 5
     lq_paths = [
-        str(root_path / '00001' / '0266' / f'im{v}.png') for v in range(1, 8)
+        str(root_path / '00001' / '0266' / f'im{v}.png')
+        for v in range(1, num_input_frames + 1)
     ]
     gt_paths = [
-        str(root_path / '00001' / '0266' / f'im{v}.png') for v in range(1, 8)
+        str(root_path / '00001' / '0266' / f'im{v}.png')
+        for v in range(1, num_input_frames + 1)
     ]
 
     with patch('builtins.open', mocked_open_function):
@@ -807,8 +811,8 @@ def test_sr_vimeo90k_mutiple_gt_dataset():
             ann_file='fake_ann_file',
             pipeline=[],
             scale=4,
+            num_input_frames=num_input_frames,
             test_mode=False)
-
         assert vimeo90k_dataset.data_infos == [
             dict(lq_path=lq_paths, gt_path=gt_paths, key='00001/0266')
         ]

--- a/tests/test_data/test_datasets/test_sr_dataset.py
+++ b/tests/test_data/test_datasets/test_sr_dataset.py
@@ -886,6 +886,45 @@ def test_sr_folder_multiple_gt_dataset():
             sequence_length=1)
     ]
 
+    # with annotation file (without num_input_frames)
+    txt_content = ('sequence_1 2\n')
+    mocked_open_function = mock_open(read_data=txt_content)
+    with patch('builtins.open', mocked_open_function):
+        # test without num_input_frames
+        test_dataset = SRFolderMultipleGTDataset(
+            lq_folder=root_path,
+            gt_folder=root_path,
+            pipeline=[],
+            scale=4,
+            ann_file='fake_ann_file',
+            test_mode=True)
+        assert test_dataset.data_infos == [
+            dict(
+                lq_path=str(root_path),
+                gt_path=str(root_path),
+                key='sequence_1',
+                num_input_frames=2,
+                sequence_length=2),
+        ]
+
+        # with annotation file (with num_input_frames)
+        test_dataset = SRFolderMultipleGTDataset(
+            lq_folder=root_path,
+            gt_folder=root_path,
+            pipeline=[],
+            scale=4,
+            ann_file='fake_ann_file',
+            num_input_frames=1,
+            test_mode=True)
+        assert test_dataset.data_infos == [
+            dict(
+                lq_path=str(root_path),
+                gt_path=str(root_path),
+                key='sequence_1',
+                num_input_frames=1,
+                sequence_length=2),
+        ]
+
     # num_input_frames must be a positive integer
     with pytest.raises(ValueError):
         SRFolderMultipleGTDataset(
@@ -928,6 +967,27 @@ def test_sr_folder_video_dataset():
             num_input_frames=5,
             max_frame_num=1),
     ]
+
+    # with annotation file
+    txt_content = ('sequence_1/00000000 2\n')
+    mocked_open_function = mock_open(read_data=txt_content)
+    with patch('builtins.open', mocked_open_function):
+        test_dataset = SRFolderVideoDataset(
+            lq_folder=root_path,
+            gt_folder=root_path,
+            num_input_frames=5,
+            pipeline=[],
+            scale=4,
+            ann_file='fake_ann_file',
+            test_mode=True)
+        assert test_dataset.data_infos == [
+            dict(
+                lq_path=str(root_path),
+                gt_path=str(root_path),
+                key='sequence_1/00000000',
+                num_input_frames=5,
+                max_frame_num=2),
+        ]
 
     # test evaluate function ('clip' mode)
     test_dataset = SRFolderVideoDataset(


### PR DESCRIPTION
## Motivation
As raised in #395, some datasets use `glob` or `scandir` when loading annotations. These functions are not compatible with ceph. As a result, it is unable to train some models when ceph is used.

## Modifications
1. For `SRFolderMultipleGTDataset` and `SRFolderVideoDataset`, an argument `ann_file` is added. If it is provided, annotations will be loaded from the file.
2. For `SRVimeo90KMultipleGTDataset`, `glob` is removed, and the file paths are replaced by the standard Vimeo-90K file names.