### PR TITLE
priority of EvalIterHook shold be lower then IterTimerHook

### DIFF
--- a/mmedit/apis/train.py
+++ b/mmedit/apis/train.py
@@ -304,7 +304,7 @@ def _non_dist_train(model,
         data_loader = build_dataloader(dataset, **val_loader_cfg)
         save_path = osp.join(cfg.work_dir, 'val_visuals')
         runner.register_hook(
-            EvalIterHook(data_loader, save_path=save_path, **cfg.evaluation), priority=80)
+            EvalIterHook(data_loader, save_path=save_path, **cfg.evaluation), priority='LOW')
 
     # user-defined hooks
     if cfg.get('custom_hooks', None):

--- a/mmedit/apis/train.py
+++ b/mmedit/apis/train.py
@@ -304,7 +304,8 @@ def _non_dist_train(model,
         data_loader = build_dataloader(dataset, **val_loader_cfg)
         save_path = osp.join(cfg.work_dir, 'val_visuals')
         runner.register_hook(
-            EvalIterHook(data_loader, save_path=save_path, **cfg.evaluation), priority='LOW')
+            EvalIterHook(data_loader, save_path=save_path, **cfg.evaluation),
+            priority='LOW')
 
     # user-defined hooks
     if cfg.get('custom_hooks', None):

--- a/mmedit/apis/train.py
+++ b/mmedit/apis/train.py
@@ -304,7 +304,7 @@ def _non_dist_train(model,
         data_loader = build_dataloader(dataset, **val_loader_cfg)
         save_path = osp.join(cfg.work_dir, 'val_visuals')
         runner.register_hook(
-            EvalIterHook(data_loader, save_path=save_path, **cfg.evaluation))
+            EvalIterHook(data_loader, save_path=save_path, **cfg.evaluation), priority=80)
 
     # user-defined hooks
     if cfg.get('custom_hooks', None):


### PR DESCRIPTION
## Motivation
when use EvalIterHook  in _non_dist_train in .mmedit/apis/train.py, it will raise keyError since the key 'data_time' is not exsist
## Modification
set the priority of EvalIterHook lower then IterTimerHook