### PR TITLE
[Enhance] Disable `dataset.evaluate` when `eval_result` is not in outputs

### DIFF
--- a/tools/test.py
+++ b/tools/test.py
@@ -120,7 +120,7 @@ def main():
             save_image=args.save_image,
             empty_cache=empty_cache)
 
-    if rank == 0:
+    if rank == 0 and 'eval_result' in outputs:
         print('')
         # print metrics
         stats = dataset.evaluate(outputs)


### PR DESCRIPTION
## Motivation
When using `test.py` without computing any metrics, `KeyError: 'eval_result'` is reported as `test.py` assumes that evaluation has been done. 

## Modification
This PR adds a condition in `test.py`. With this modification, `dataset.evaluate` is bypassed if `eval_result` is not contained in `outputs`.