### PR TITLE
[Fix] Fix JPEG Compression in OpenCV 4.5.4

### DIFF
--- a/mmedit/datasets/pipelines/random_degradations.py
+++ b/mmedit/datasets/pipelines/random_degradations.py
@@ -291,7 +291,7 @@ class RandomJPEGCompression:
 
         # determine compression level
         quality = self.params['quality']
-        jpeg_param = np.random.uniform(quality[0], quality[1])
+        jpeg_param = round(np.random.uniform(quality[0], quality[1]))
         encode_param = [int(cv2.IMWRITE_JPEG_QUALITY), jpeg_param]
 
         # apply jpeg compression


### PR DESCRIPTION
## Motivation
`cv2.imencode` accepts floating-point compression factor in version 4.5.2. However, it accepts only integer factor in 4.5.4

## Modification
This PR fixes the problem by rounding off the randomly sampled factor.