### PR TITLE
[Fix] Change target_size for RandomResize from list to tuple

### DIFF
--- a/configs/restorers/glean/glean_in128out1024_4x2_300k_ffhq_celebahq.py
+++ b/configs/restorers/glean/glean_in128out1024_4x2_300k_ffhq_celebahq.py
@@ -93,7 +93,7 @@ train_pipeline = [
     dict(
         type='RandomResize',
         params=dict(
-            target_size=[1024, 1024],
+            target_size=(1024, 1024),
             resize_opt=['bilinear', 'area', 'bicubic'],
             resize_prob=[1 / 3., 1 / 3., 1 / 3.]),
         keys=['lq'],
@@ -102,7 +102,7 @@ train_pipeline = [
     dict(
         type='RandomResize',
         params=dict(
-            target_size=[128, 128], resize_opt=['area'], resize_prob=[1]),
+            target_size=(128, 128), resize_opt=['area'], resize_prob=[1]),
         keys=['lq'],
     ),
     dict(
@@ -136,7 +136,7 @@ demo_pipeline = [
     dict(
         type='RandomResize',
         params=dict(
-            target_size=[128, 128], resize_opt=['area'], resize_prob=[1]),
+            target_size=(128, 128), resize_opt=['area'], resize_prob=[1]),
         keys=['lq'],
     ),
     dict(type='RescaleToZeroOne', keys=['lq']),

--- a/configs/restorers/real_esrgan/realesrnet_c64b23g32_12x4_lr2e-4_1000k_df2k_ost.py
+++ b/configs/restorers/real_esrgan/realesrnet_c64b23g32_12x4_lr2e-4_1000k_df2k_ost.py
@@ -126,7 +126,7 @@ train_pipeline = [
                 dict(
                     type='RandomResize',
                     params=dict(
-                        target_size=[100, 100],
+                        target_size=(100, 100),
                         resize_opt=['bilinear', 'area', 'bicubic'],
                         resize_prob=[1 / 3., 1 / 3., 1 / 3.]),
                 ),

--- a/tests/test_data/test_pipelines/test_random_degradations.py
+++ b/tests/test_data/test_pipelines/test_random_degradations.py
@@ -111,7 +111,7 @@ def test_random_resize():
             resize_scale=[0.5, 1.5],
             resize_opt=['bilinear', 'area', 'bicubic'],
             resize_prob=[1 / 3., 1 / 3., 1 / 3.],
-            target_size=[16, 16]),
+            target_size=(16, 16)),
         keys=['lq'])
     results = model(results)
     assert results['lq'].shape == (16, 16, 3)
@@ -302,7 +302,7 @@ def test_degradations_with_shuffle():
                     resize_scale=[0.5, 1.5],
                     resize_opt=['bilinear', 'area', 'bicubic'],
                     resize_prob=[1 / 3., 1 / 3., 1 / 3.],
-                    target_size=[16, 16])),
+                    target_size=(16, 16))),
             [
                 dict(
                     type='RandomJPEGCompression',
@@ -335,7 +335,7 @@ def test_degradations_with_shuffle():
                 resize_scale=[0.5, 1.5],
                 resize_opt=['bilinear', 'area', 'bicubic'],
                 resize_prob=[1 / 3., 1 / 3., 1 / 3.],
-                target_size=[16, 16])),
+                target_size=(16, 16))),
         [
             dict(type='RandomJPEGCompression', params=dict(quality=[5, 10])),
             dict(type='RandomJPEGCompression', params=dict(quality=[15, 20]))


### PR DESCRIPTION
## Motivation
As stated in #616, when using `RandomResize`, an error is raised when list is used for `target_size`.

## Modification
This PR fixes the problem by changing `target_size` from list to tuple in the configuration files. 