### PR TITLE
[Feature] Support conversion to y-channel when loading images

### DIFF
--- a/mmedit/datasets/pipelines/loading.py
+++ b/mmedit/datasets/pipelines/loading.py
@@ -20,6 +20,8 @@ class LoadImageFromFile:
         flag (str): Loading flag for images. Default: 'color'.
         channel_order (str): Order of channel, candidates are 'bgr' and 'rgb'.
             Default: 'bgr'.
+        convert_to (str | None): The color space of the output image. If None,
+            no conversion is conducted. Default: None.
         save_original_img (bool): If True, maintain a copy of the image in
             `results` dict with name of `f'ori_{key}'`. Default: False.
         use_cache (bool): If True, load all images at once. Default: False.
@@ -33,15 +35,18 @@ class LoadImageFromFile:
                  key='gt',
                  flag='color',
                  channel_order='bgr',
+                 convert_to=None,
                  save_original_img=False,
                  use_cache=False,
                  backend=None,
                  **kwargs):
+
         self.io_backend = io_backend
         self.key = key
         self.flag = flag
         self.save_original_img = save_original_img
         self.channel_order = channel_order
+        self.convert_to = convert_to
         self.kwargs = kwargs
         self.file_client = None
         self.use_cache = use_cache
@@ -81,6 +86,18 @@ class LoadImageFromFile:
                 flag=self.flag,
                 channel_order=self.channel_order,
                 backend=self.backend)  # HWC
+
+        if self.convert_to is not None:
+            if self.channel_order == 'bgr' and self.convert_to.lower() == 'y':
+                img = mmcv.bgr2ycbcr(img, y_only=True)
+            elif self.channel_order == 'rgb':
+                img = mmcv.rgb2ycbcr(img, y_only=True)
+            else:
+                raise ValueError('Currently support only "bgr2ycbcr" or '
+                                 '"bgr2ycbcr".')
+            if img.ndim == 2:
+                img = np.expand_dims(img, axis=2)
+
         results[self.key] = img
         results[f'{self.key}_path'] = filepath
         results[f'{self.key}_ori_shape'] = img.shape
@@ -111,6 +128,8 @@ class LoadImageFromFileList(LoadImageFromFile):
         flag (str): Loading flag for images. Default: 'color'.
         channel_order (str): Order of channel, candidates are 'bgr' and 'rgb'.
             Default: 'bgr'.
+        convert_to (str | None): The color space of the output image. If None,
+            no conversion is conducted. Default: None.
         save_original_img (bool): If True, maintain a copy of the image in
             `results` dict with name of `f'ori_{key}'`. Default: False.
         kwargs (dict): Args for file client.
@@ -145,8 +164,21 @@ class LoadImageFromFileList(LoadImageFromFile):
             img = mmcv.imfrombytes(
                 img_bytes, flag=self.flag,
                 channel_order=self.channel_order)  # HWC
+
+            # convert to y-channel, if specified
+            if self.convert_to is not None:
+                if self.channel_order == 'bgr' and self.convert_to.lower(
+                ) == 'y':
+                    img = mmcv.bgr2ycbcr(img, y_only=True)
+                elif self.channel_order == 'rgb':
+                    img = mmcv.rgb2ycbcr(img, y_only=True)
+                else:
+                    raise ValueError('Currently support only "bgr2ycbcr" or '
+                                     '"bgr2ycbcr".')
+
             if img.ndim == 2:
                 img = np.expand_dims(img, axis=2)
+
             imgs.append(img)
             shapes.append(img.shape)
             if self.save_original_img:
@@ -464,6 +496,8 @@ class LoadPairedImageFromFile(LoadImageFromFile):
         flag (str): Loading flag for images. Default: 'color'.
         channel_order (str): Order of channel, candidates are 'bgr' and 'rgb'.
             Default: 'bgr'.
+        convert_to (str | None): The color space of the output image. If None,
+            no conversion is conducted. Default: None.
         save_original_img (bool): If True, maintain a copy of the image in
             `results` dict with name of `f'ori_{key}'`. Default: False.
         kwargs (dict): Args for file client.

--- a/mmedit/datasets/pipelines/loading.py
+++ b/mmedit/datasets/pipelines/loading.py
@@ -496,8 +496,6 @@ class LoadPairedImageFromFile(LoadImageFromFile):
         flag (str): Loading flag for images. Default: 'color'.
         channel_order (str): Order of channel, candidates are 'bgr' and 'rgb'.
             Default: 'bgr'.
-        convert_to (str | None): The color space of the output image. If None,
-            no conversion is conducted. Default: None.
         save_original_img (bool): If True, maintain a copy of the image in
             `results` dict with name of `f'ori_{key}'`. Default: False.
         kwargs (dict): Args for file client.

--- a/tests/test_data/test_pipelines/test_loading.py
+++ b/tests/test_data/test_pipelines/test_loading.py
@@ -87,6 +87,36 @@ def test_load_image_from_file():
     assert results['gt_path'] == str(path_baboon)
     np.testing.assert_almost_equal(results['gt'], img_baboon)
 
+    # convert to y-channel (bgr2y)
+    results = dict(gt_path=path_baboon)
+    config = dict(io_backend='disk', key='gt', convert_to='y')
+    image_loader = LoadImageFromFile(**config)
+    results = image_loader(results)
+    assert results['gt'].shape == (480, 500, 1)
+    img_baboon_y = mmcv.bgr2ycbcr(img_baboon, y_only=True)
+    img_baboon_y = np.expand_dims(img_baboon_y, axis=2)
+    np.testing.assert_almost_equal(results['gt'], img_baboon_y)
+    assert results['gt_path'] == str(path_baboon)
+
+    # convert to y-channel (rgb2y)
+    results = dict(gt_path=path_baboon)
+    config = dict(
+        io_backend='disk', key='gt', channel_order='rgb', convert_to='y')
+    image_loader = LoadImageFromFile(**config)
+    results = image_loader(results)
+    assert results['gt'].shape == (480, 500, 1)
+    img_baboon_y = mmcv.bgr2ycbcr(img_baboon, y_only=True)
+    img_baboon_y = np.expand_dims(img_baboon_y, axis=2)
+    np.testing.assert_almost_equal(results['gt'], img_baboon_y)
+    assert results['gt_path'] == str(path_baboon)
+
+    # convert to y-channel (ValueError)
+    results = dict(gt_path=path_baboon)
+    config = dict(io_backend='disk', key='gt', convert_to='abc')
+    image_loader = LoadImageFromFile(**config)
+    with pytest.raises(ValueError):
+        results = image_loader(results)
+
 
 def test_load_image_from_file_list():
     path_baboon = Path(
@@ -128,6 +158,36 @@ def test_load_image_from_file_list():
         # filepath should be list
         results = dict(lq_path=path_baboon_x4)
         image_loader(results)
+
+    # convert to y-channel (bgr2y)
+    results = dict(lq_path=[str(path_baboon_x4), str(path_baboon)])
+    config = dict(io_backend='disk', key='lq', convert_to='y')
+    image_loader = LoadImageFromFileList(**config)
+    results = image_loader(results)
+    img_baboon_x4_y = mmcv.bgr2ycbcr(img_baboon_x4, y_only=True)
+    img_baboon_y = mmcv.bgr2ycbcr(img_baboon, y_only=True)
+    img_baboon_x4_y = np.expand_dims(img_baboon_x4_y, axis=2)
+    img_baboon_y = np.expand_dims(img_baboon_y, axis=2)
+    np.testing.assert_almost_equal(results['lq'][0], img_baboon_x4_y)
+    np.testing.assert_almost_equal(results['lq'][1], img_baboon_y)
+    assert results['lq_path'] == [str(path_baboon_x4), str(path_baboon)]
+
+    # convert to y-channel (rgb2y)
+    results = dict(lq_path=[str(path_baboon_x4), str(path_baboon)])
+    config = dict(
+        io_backend='disk', key='lq', channel_order='rgb', convert_to='y')
+    image_loader = LoadImageFromFileList(**config)
+    results = image_loader(results)
+    np.testing.assert_almost_equal(results['lq'][0], img_baboon_x4_y)
+    np.testing.assert_almost_equal(results['lq'][1], img_baboon_y)
+    assert results['lq_path'] == [str(path_baboon_x4), str(path_baboon)]
+
+    # convert to y-channel (ValueError)
+    results = dict(lq_path=[str(path_baboon_x4), str(path_baboon)])
+    config = dict(io_backend='disk', key='lq', convert_to='abc')
+    image_loader = LoadImageFromFileList(**config)
+    with pytest.raises(ValueError):
+        results = image_loader(results)
 
 
 class TestMattingLoading:


### PR DESCRIPTION
## Motivation
As suggested by #642, support conversion to y-channel images, since some models are trained on y-channels.

## Modifications
Modify **mmedit/datasets/pipelines/loading.py** by adding the argument `convert_to` in the corresponding functions.