### PR TITLE
[Fix] Remove outdated code in docs/conf.py

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -16,8 +16,6 @@ import subprocess
 import sys
 
 import pytorch_sphinx_theme
-from m2r import MdInclude
-from recommonmark.transform import AutoStructify
 
 sys.path.insert(0, os.path.abspath('..'))
 
@@ -37,7 +35,6 @@ extensions = [
     'sphinx.ext.napoleon',
     'sphinx.ext.viewcode',
     'sphinx_markdown_tables',
-    'sphinx.ext.autosectionlabel',
     'sphinx_copybutton',
     'myst_parser',
 ]
@@ -168,17 +165,3 @@ master_doc = 'index'
 def builder_inited_handler(app):
     subprocess.run(['./merge_docs.sh'])
     subprocess.run(['./stat.py'])
-
-
-def setup(app):
-    app.connect('builder-inited', builder_inited_handler)
-    app.add_config_value('no_underscore_emphasis', False, 'env')
-    app.add_config_value('m2r_parse_relative_links', False, 'env')
-    app.add_config_value('m2r_anonymous_references', False, 'env')
-    app.add_config_value('m2r_disable_inline_math', False, 'env')
-    app.add_directive('mdinclude', MdInclude)
-    app.add_config_value('recommonmark_config', {
-        'auto_toc_tree_section': 'Contents',
-        'enable_eval_rst': True,
-    }, True)
-    app.add_transform(AutoStructify)

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -1,5 +1,4 @@
 docutils==0.16.0
-m2r
 mmcls==0.10.0
 myst_parser
 -e git+https://github.com/open-mmlab/pytorch_sphinx_theme.git#egg=pytorch_sphinx_theme

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,6 +19,6 @@ line_length = 79
 multi_line_output = 0
 known_standard_library = pkg_resources,setuptools
 known_first_party = mmedit
-known_third_party =PIL,cv2,lmdb,m2r,mmcv,numpy,onnx,onnxruntime,packaging,pymatting,pytest,pytorch_sphinx_theme,recommonmark,requests,scipy,titlecase,torch,torchvision,ts
+known_third_party =PIL,cv2,lmdb,mmcv,numpy,onnx,onnxruntime,packaging,pymatting,pytest,pytorch_sphinx_theme,requests,scipy,titlecase,torch,torchvision,ts
 no_lines_before = STDLIB,LOCALFOLDER
 default_section = THIRDPARTY


### PR DESCRIPTION
## Motivation
Fix the error when building HTML (https://readthedocs.org/projects/mmcv/builds/15458392/)

Reference: https://github.com/open-mmlab/mmcv/pull/1560

## Modifications
- docs/conf.py
- setup.cfg
- requirements/docs.txt