### PR TITLE
[Fix] Fix flow_warp comment

### DIFF
--- a/mmedit/models/common/flow_warp.py
+++ b/mmedit/models/common/flow_warp.py
@@ -30,7 +30,7 @@ def flow_warp(x,
     _, _, h, w = x.size()
     # create mesh grid
     grid_y, grid_x = torch.meshgrid(torch.arange(0, h), torch.arange(0, w))
-    grid = torch.stack((grid_x, grid_y), 2).type_as(x)  # (w, h, 2)
+    grid = torch.stack((grid_x, grid_y), 2).type_as(x)  # (h, w, 2)
     grid.requires_grad = False
 
     grid_flow = grid + flow


### PR DESCRIPTION
## Motivation
As reported in #638, the comment of `flow_warp` has a problem. This PR fixes the comment by changing `(w, h, 2)` to `(h, w, 2)`.
 
## Modification
Modify `mmedit/models/common/flow_warp.py`.