### PR TITLE
Update ESRGAN config path in getting_started.md

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -118,7 +118,7 @@ python demo/restoration_demo.py ${CONFIG_FILE} ${CHECKPOINT_FILE} ${IMAGE_FILE} 
 If `--imshow` is specified, the demo will also show image with opencv. Examples:
 
 ```shell
-python demo/restoration_demo.py configs/restorers/esrgan/esrgan_x4c64b23g32_1x16_400k_div2k.py work_dirs/esrgan_x4c64b23g32_1x16_400k_div2k/latest.pth tests/data/lq/baboon_x4.png demo/demo_out_baboon.png
+python demo/restoration_demo.py configs/restorers/esrgan/esrgan_x4c64b23g32_g1_400k_div2k.py work_dirs/esrgan_x4c64b23g32_1x16_400k_div2k/latest.pth tests/data/lq/baboon_x4.png demo/demo_out_baboon.png
 ```
 
 The restored image will be save in `demo/demo_out_baboon.png`.


### PR DESCRIPTION
The  “configs\restorers\esrgan\esrgan_x4c64b23g32_1x16_400k_div2k.py" does not exist
But when I change the command to esrgan_x4c64b23g32_g1_400k_div2k.py it can work.
![b219f5cc567bbdbdffa1a51e137afaf](https://user-images.githubusercontent.com/45811724/146095537-caa066cb-a324-409f-906b-9f1979a5858a.png)
 