### PR TITLE
Update GLEAN config path in demo.md

### DIFF
--- a/docs/demo.md
+++ b/docs/demo.md
@@ -59,7 +59,7 @@ python demo/restoration_face_demo.py ${CONFIG_FILE} ${CHECKPOINT_FILE} ${IMAGE_F
 If `--imshow` is specified, the demo will also show image with opencv. Examples:
 
 ```shell
-python demo/restoration_face_demo.py configs/restorers/glean/glean_in128out1024_2x4_300k_ffhq_celebahq.py https://download.openmmlab.com/mmediting/restorers/glean/glean_in128out1024_4x2_300k_ffhq_celebahq_20210812-acbcb04f.pth tests/data/face/000001.png results/000001.png --upscale_factor 4
+python demo/restoration_face_demo.py configs/restorers/glean/glean_in128out1024_4x2_300k_ffhq_celebahq.py https://download.openmmlab.com/mmediting/restorers/glean/glean_in128out1024_4x2_300k_ffhq_celebahq_20210812-acbcb04f.pth tests/data/face/000001.png results/000001.png --upscale_factor 4
 ```
 
 #### Restoration (Video)


### PR DESCRIPTION
\configs\restorers\glean\glean_in128out1024_2x4_300k_ffhq_celebahq.py" does not exist
When I change the commmand to /configs/restorers/glean/glean_in128out1024_4x2_300k_ffhq_celebahq.py it can work
![4b327e4bc36af04595c6f5b71bc97f3](https://user-images.githubusercontent.com/45811724/146096657-c0969580-f9ec-46d1-9f1d-6fd9b7b405d8.png)
![42dc332fb5a23ad1a4be061138da77f](https://user-images.githubusercontent.com/45811724/146096659-6261b82f-903a-4458-bea8-e9fcb22b246e.png)

