### PR TITLE
[Enhance]: Use mmcv root model registry.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,7 +60,7 @@ jobs:
         run: pip install torch==${{matrix.torch}}+cpu torchvision==${{matrix.torchvision}}+cpu -f https://download.pytorch.org/whl/torch_stable.html
       - name: Install MMCV
         run: |
-          pip install mmcv-full==1.3.0 -f https://download.openmmlab.com/mmcv/dist/cpu/torch${{matrix.torch}}/index.html
+          pip install mmcv-full==1.3.1 -f https://download.openmmlab.com/mmcv/dist/cpu/torch${{matrix.torch}}/index.html
           python -c 'import mmcv; print(mmcv.__version__)'
       - name: Install FaceXLib
         run: pip install facexlib
@@ -142,7 +142,7 @@ jobs:
       - name: Install MMCV
         run: |
           python -V
-          python -m pip install mmcv-full==1.3.0 -f https://download.openmmlab.com/mmcv/dist/cu101/${{matrix.mmcv_link}}/index.html
+          python -m pip install mmcv-full==1.3.1 -f https://download.openmmlab.com/mmcv/dist/cu101/${{matrix.mmcv_link}}/index.html
           python -c 'import mmcv; print(mmcv.__version__)'
       - name: Install FaceXLib
         run: python -m pip install facexlib
@@ -210,7 +210,7 @@ jobs:
       - name: Install MMCV
         run: |
           python -V
-          python -m pip install mmcv-full==1.3.0 -f https://download.openmmlab.com/mmcv/dist/cu102/${{matrix.mmcv_link}}/index.html
+          python -m pip install mmcv-full==1.3.1 -f https://download.openmmlab.com/mmcv/dist/cu102/${{matrix.mmcv_link}}/index.html
           python -c 'import mmcv; print(mmcv.__version__)'
       - name: Install FaceXLib
         run: python -m pip install facexlib

--- a/mmedit/__init__.py
+++ b/mmedit/__init__.py
@@ -19,7 +19,7 @@ except ImportError:
         return digit_ver
 
 
-MMCV_MIN = '1.3'
+MMCV_MIN = '1.3.1'
 MMCV_MAX = '1.5'
 
 mmcv_min_version = digit_version(MMCV_MIN)

--- a/mmedit/models/registry.py
+++ b/mmedit/models/registry.py
@@ -1,7 +1,8 @@
 # Copyright (c) OpenMMLab. All rights reserved.
+from mmcv.cnn import MODELS as MMCV_MODELS
 from mmcv.utils import Registry
 
-MODELS = Registry('model')
-BACKBONES = Registry('backbone')
-COMPONENTS = Registry('component')
-LOSSES = Registry('loss')
+MODELS = Registry('model', parent=MMCV_MODELS)
+BACKBONES = MODELS
+COMPONENTS = MODELS
+LOSSES = MODELS

--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -1,5 +1,5 @@
 lmdb
-mmcv-full>=1.2.0
+mmcv-full>=1.3.1
 scikit-image
 tensorboard
 yapf


### PR DESCRIPTION
## Motivation

MMEditing did not use mmcv's MODELS registry as root/parent registry. This PR makes it impossible to build models across projects.

## Modification

mmpose/models/registry.py

```Python
from mmcv.cnn import MODELS as MMCV_MODELS
from mmcv.utils import Registry

MODELS = Registry('model', parent=MMCV_MODELS)
BACKBONES = MODELS
COMPONENTS = MODELS
LOSSES = MODELS

MODELS = Registry(
    'models', build_func=build_model_from_cfg, parent=MMCV_MODELS)
```
