### PR TITLE
[Doc] Fix the error of Model Zoo and Datasets in docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -165,3 +165,7 @@ master_doc = 'index'
 def builder_inited_handler(app):
     subprocess.run(['./merge_docs.sh'])
     subprocess.run(['./stat.py'])
+
+
+def setup(app):
+    app.connect('builder-inited', builder_inited_handler)


### PR DESCRIPTION
## Motivations
In #644, Model Zoo and Datasets disappeared in readthedocs. This PR adds them back.

## Modifications
Modify **conf.py**