### PR TITLE
[Feature] Add argument 'repeat' to SRREDSMultipleGTDataset

### DIFF
--- a/configs/restorers/basicvsr_plusplus/basicvsr_plusplus_c64n7_8x1_600k_reds4.py
+++ b/configs/restorers/basicvsr_plusplus/basicvsr_plusplus_c64n7_8x1_600k_reds4.py
@@ -102,6 +102,7 @@ data = dict(
         pipeline=test_pipeline,
         scale=4,
         val_partition='REDS4',
+        repeat=2,
         test_mode=True),
     # test
     test=dict(

--- a/mmedit/datasets/sr_reds_multiple_gt_dataset.py
+++ b/mmedit/datasets/sr_reds_multiple_gt_dataset.py
@@ -44,8 +44,8 @@ class SRREDSMultipleGTDataset(BaseSRDataset):
         self.data_infos = self.load_annotations()
 
         if not isinstance(repeat, int):
-            raise ValueError('"repeat" must be an integer, but got '
-                             f'{type(repeat)}.')
+            raise TypeError('"repeat" must be an integer, but got '
+                            f'{type(repeat)}.')
 
     def load_annotations(self):
         """Load annoations for REDS dataset.

--- a/mmedit/datasets/sr_reds_multiple_gt_dataset.py
+++ b/mmedit/datasets/sr_reds_multiple_gt_dataset.py
@@ -35,17 +35,18 @@ class SRREDSMultipleGTDataset(BaseSRDataset):
                  val_partition='official',
                  repeat=1,
                  test_mode=False):
+
+        self.repeat = repeat
+        if not isinstance(repeat, int):
+            raise TypeError('"repeat" must be an integer, but got '
+                            f'{type(repeat)}.')
+
         super().__init__(pipeline, scale, test_mode)
         self.lq_folder = str(lq_folder)
         self.gt_folder = str(gt_folder)
         self.num_input_frames = num_input_frames
         self.val_partition = val_partition
-        self.repeat = repeat
         self.data_infos = self.load_annotations()
-
-        if not isinstance(repeat, int):
-            raise TypeError('"repeat" must be an integer, but got '
-                            f'{type(repeat)}.')
 
     def load_annotations(self):
         """Load annoations for REDS dataset.

--- a/tests/test_data/test_datasets/test_sr_dataset.py
+++ b/tests/test_data/test_datasets/test_sr_dataset.py
@@ -1095,7 +1095,3 @@ def test_sr_folder_video_dataset():
     # The length of results should be equal to the dataset len
     with pytest.raises(AssertionError):
         test_dataset.evaluate(results=[results[0]])
-
-
-if __name__ == '__main__':
-    test_sr_reds_multiple_gt_dataset()

--- a/tests/test_data/test_datasets/test_sr_dataset.py
+++ b/tests/test_data/test_datasets/test_sr_dataset.py
@@ -807,8 +807,9 @@ def test_sr_reds_multiple_gt_dataset():
         sequence_length=100,
         num_input_frames=5)
 
+    # REDS4 val partition (repeat != int)
     with pytest.raises(TypeError):
-        reds_dataset = SRREDSMultipleGTDataset(
+        SRREDSMultipleGTDataset(
             lq_folder=root_path,
             gt_folder=root_path,
             num_input_frames=5,
@@ -1094,3 +1095,7 @@ def test_sr_folder_video_dataset():
     # The length of results should be equal to the dataset len
     with pytest.raises(AssertionError):
         test_dataset.evaluate(results=[results[0]])
+
+
+if __name__ == '__main__':
+    test_sr_reds_multiple_gt_dataset()

--- a/tests/test_data/test_datasets/test_sr_dataset.py
+++ b/tests/test_data/test_datasets/test_sr_dataset.py
@@ -788,6 +788,36 @@ def test_sr_reds_multiple_gt_dataset():
         sequence_length=100,
         num_input_frames=5)
 
+    # REDS4 val partition (repeat > 1)
+    reds_dataset = SRREDSMultipleGTDataset(
+        lq_folder=root_path,
+        gt_folder=root_path,
+        num_input_frames=5,
+        pipeline=[],
+        scale=4,
+        val_partition='REDS4',
+        repeat=2,
+        test_mode=True)
+
+    assert len(reds_dataset.data_infos) == 8  # 4 test clips
+    assert reds_dataset.data_infos[5] == dict(
+        lq_path=str(root_path),
+        gt_path=str(root_path),
+        key='011',
+        sequence_length=100,
+        num_input_frames=5)
+
+    with pytest.raises(TypeError):
+        reds_dataset = SRREDSMultipleGTDataset(
+            lq_folder=root_path,
+            gt_folder=root_path,
+            num_input_frames=5,
+            pipeline=[],
+            scale=4,
+            val_partition='REDS4',
+            repeat=1.5,
+            test_mode=True)
+
 
 def test_sr_vimeo90k_mutiple_gt_dataset():
     root_path = Path(__file__).parent.parent.parent / 'data/vimeo90k'


### PR DESCRIPTION
## Motivation
As indicated in #671, training BasicVSR++ with 8 GPUs causes an error, since REDS4 contains 4 validation folders, which cannot be tested with 8 GPUs. This PR fixes the issue by repeating the validation data (e.g. from 4 folders to 8)

## Modification
1. Modify mmedit/datasets/sr_reds_multiple_gt_dataset.py
2. Modify config of BasicVSR++