### PR TITLE
Limit opencv-python version

### DIFF
--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -1,6 +1,6 @@
 lmdb
 mmcv-full>=1.3.1
-opencv-python<=4.3.0.36
+opencv-python-headless<=4.5.4.60
 scikit-image
 tensorboard
 yapf

--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -1,5 +1,6 @@
 lmdb
 mmcv-full>=1.3.1
+opencv-python<=4.3.0.36
 scikit-image
 tensorboard
 yapf


### PR DESCRIPTION
## Motivation
The latest `opencv-python` causes error in CI. This PR limits the version of it.

# Modification
Modify requirements/runtime.txt