### PR TITLE
[CI] Update Pillow from 6.2.2 to 8.4 in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,6 +55,7 @@ jobs:
         run: pip install pip --upgrade
       - name: Install Pillow
         run: pip install Pillow<9
+        if: ${{matrix.torchvision == '0.4.1'}}
       - name: Install PyTorch
         run: pip install torch==${{matrix.torch}}+cpu torchvision==${{matrix.torchvision}}+cpu -f https://download.pytorch.org/whl/torch_stable.html
       - name: Install MMCV

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -136,7 +136,7 @@ jobs:
           rm -rf /var/lib/apt/lists/*
       - name: Install Pillow
         run: python -m pip install "Pillow<9"
-        if: ${{matrix.torchvision < 0.5}}
+        if: ${{matrix.torchvision == '0.4.1'}}
       - name: Install PyTorch
         run: python -m pip install torch==${{matrix.torch}} torchvision==${{matrix.torchvision}} -f https://download.pytorch.org/whl/torch_stable.html
       - name: Install MMCV

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,8 +54,7 @@ jobs:
       - name: Upgrade pip
         run: pip install pip --upgrade
       - name: Install Pillow
-        run: pip install Pillow==6.2.2
-        if: ${{matrix.torchvision == '0.4.1'}}
+        run: pip install Pillow<9
       - name: Install PyTorch
         run: pip install torch==${{matrix.torch}}+cpu torchvision==${{matrix.torchvision}}+cpu -f https://download.pytorch.org/whl/torch_stable.html
       - name: Install MMCV

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Upgrade pip
         run: pip install pip --upgrade
       - name: Install Pillow
-        run: pip install Pillow<9
+        run: pip install "Pillow<9"
         if: ${{matrix.torchvision == '0.4.1'}}
       - name: Install PyTorch
         run: pip install torch==${{matrix.torch}}+cpu torchvision==${{matrix.torchvision}}+cpu -f https://download.pytorch.org/whl/torch_stable.html
@@ -135,7 +135,7 @@ jobs:
           apt-get clean
           rm -rf /var/lib/apt/lists/*
       - name: Install Pillow
-        run: python -m pip install Pillow==6.2.2
+        run: python -m pip install "Pillow<9"
         if: ${{matrix.torchvision < 0.5}}
       - name: Install PyTorch
         run: python -m pip install torch==${{matrix.torch}} torchvision==${{matrix.torchvision}} -f https://download.pytorch.org/whl/torch_stable.html


### PR DESCRIPTION
In order to solve: https://github.com/open-mmlab/mmediting/runs/4697550155?check_suite_focus=true#step:12:109

In the previous GitHub workflow, installation of Pillow==6.2.2 is useless because it will be overwritten afterward in `pip install -r requirements.txt`. The actual version installed finally is 8.4.0. This version is compatible with old torchvision because `PILLOW_VERSION` is re-imported (which is removed in version 7), so previous CI works until 2022-Jan-02 when Pillow 9 was released. So I tried to use Pillow<9 to keep this compatibility with old-versioned torchvision as well as other dependencies. 