### PR TITLE
[Enhance] Put LQ into CPU for restoration_video_demo

### DIFF
--- a/mmedit/apis/restoration_video_inference.py
+++ b/mmedit/apis/restoration_video_inference.py
@@ -1,13 +1,10 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 import glob
-import os.path as osp
-import re
-from functools import reduce
+import os
 
 import mmcv
 import numpy as np
 import torch
-from mmcv.parallel import collate, scatter
 
 from mmedit.datasets.pipelines import Compose
 
@@ -63,7 +60,7 @@ def restoration_video_inference(model,
         test_pipeline = model.cfg.val_pipeline
 
     # check if the input is a video
-    file_extension = osp.splitext(img_dir)[1]
+    file_extension = os.path.splitext(img_dir)[1]
     if file_extension in VIDEO_EXTENSIONS:
         video_reader = mmcv.VideoReader(img_dir)
         # load the images
@@ -91,10 +88,9 @@ def restoration_video_inference(model,
         test_pipeline[0]['filename_tmpl'] = filename_tmpl
 
         # prepare data
-        sequence_length = len(glob.glob(osp.join(img_dir, '*')))
-        img_dir_split = re.split(r'[\\/]', img_dir)
-        key = img_dir_split[-1]
-        lq_folder = reduce(osp.join, img_dir_split[:-1])
+        sequence_length = len(glob.glob(f'{img_dir}/*'))
+        key = img_dir.split('/')[-1]
+        lq_folder = '/'.join(img_dir.split('/')[:-1])
         data = dict(
             lq_path=lq_folder,
             gt_path='',
@@ -104,24 +100,28 @@ def restoration_video_inference(model,
     # compose the pipeline
     test_pipeline = Compose(test_pipeline)
     data = test_pipeline(data)
-    data = scatter(collate([data], samples_per_gpu=1), [device])[0]['lq']
+    data = data['lq'].unsqueeze(0)  # in cpu
+
     # forward the model
     with torch.no_grad():
         if window_size > 0:  # sliding window framework
             data = pad_sequence(data, window_size)
             result = []
             for i in range(0, data.size(1) - 2 * (window_size // 2)):
-                data_i = data[:, i:i + window_size]
+                data_i = data[:, i:i + window_size].to(device)
                 result.append(model(lq=data_i, test_mode=True)['output'].cpu())
             result = torch.stack(result, dim=1)
         else:  # recurrent framework
             if max_seq_len is None:
-                result = model(lq=data, test_mode=True)['output'].cpu()
+                result = model(
+                    lq=data.to(device), test_mode=True)['output'].cpu()
             else:
                 result = []
                 for i in range(0, data.size(1), max_seq_len):
                     result.append(
-                        model(lq=data[:, i:i + max_seq_len],
-                              test_mode=True)['output'].cpu())
+                        model(
+                            lq=data.to(device)[:,
+                                               i:i + max_seq_len].to(device),
+                            test_mode=True)['output'].cpu())
                 result = torch.cat(result, dim=1)
     return result

--- a/mmedit/apis/restoration_video_inference.py
+++ b/mmedit/apis/restoration_video_inference.py
@@ -1,6 +1,8 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 import glob
-import os
+import os.path as osp
+import re
+from functools import reduce
 
 import mmcv
 import numpy as np
@@ -60,7 +62,7 @@ def restoration_video_inference(model,
         test_pipeline = model.cfg.val_pipeline
 
     # check if the input is a video
-    file_extension = os.path.splitext(img_dir)[1]
+    file_extension = osp.splitext(img_dir)[1]
     if file_extension in VIDEO_EXTENSIONS:
         video_reader = mmcv.VideoReader(img_dir)
         # load the images
@@ -88,9 +90,10 @@ def restoration_video_inference(model,
         test_pipeline[0]['filename_tmpl'] = filename_tmpl
 
         # prepare data
-        sequence_length = len(glob.glob(f'{img_dir}/*'))
-        key = img_dir.split('/')[-1]
-        lq_folder = '/'.join(img_dir.split('/')[:-1])
+        sequence_length = len(glob.glob(osp.join(img_dir, '*')))
+        img_dir_split = re.split(r'[\\/]', img_dir)
+        key = img_dir_split[-1]
+        lq_folder = reduce(osp.join, img_dir_split[:-1])
         data = dict(
             lq_path=lq_folder,
             gt_path='',
@@ -120,8 +123,7 @@ def restoration_video_inference(model,
                 for i in range(0, data.size(1), max_seq_len):
                     result.append(
                         model(
-                            lq=data.to(device)[:,
-                                               i:i + max_seq_len].to(device),
+                            lq=data[:, i:i + max_seq_len].to(device),
                             test_mode=True)['output'].cpu())
                 result = torch.cat(result, dim=1)
     return result


### PR DESCRIPTION
## Motivation
Instead of loading all LQ images to GPU, which causes CUDA OOM, we first put them in CPU, and then extract to GPU when we use them.

## Modifiication
- Modify `mmedit/apis/restoration_video_inference.py`