### PR TITLE
[Fix] `flip_ratio` in `RandomAffine` pipeline is inverted

### DIFF
--- a/mmedit/datasets/pipelines/augmentation.py
+++ b/mmedit/datasets/pipelines/augmentation.py
@@ -480,7 +480,6 @@ class RandomAffine:
 
         angle = math.radians(angle)
         shear = math.radians(shear)
-        # print(flip)
         scale_x = 1.0 / scale[0] * flip[0]
         scale_y = 1.0 / scale[1] * flip[1]
 
@@ -531,8 +530,6 @@ class RandomAffine:
         M = np.array(M).reshape((2, 3))
 
         for key in self.keys:
-            # print(key)
-            # print(M)
             results[key] = cv2.warpAffine(
                 results[key],
                 M, (w, h),

--- a/mmedit/datasets/pipelines/augmentation.py
+++ b/mmedit/datasets/pipelines/augmentation.py
@@ -480,6 +480,7 @@ class RandomAffine:
 
         angle = math.radians(angle)
         shear = math.radians(shear)
+        # print(flip)
         scale_x = 1.0 / scale[0] * flip[0]
         scale_y = 1.0 / scale[1] * flip[1]
 
@@ -525,11 +526,13 @@ class RandomAffine:
             params = self._get_params(self.degrees, self.translate, self.scale,
                                       self.shear, self.flip_ratio, (h, w))
 
-        center = (w * 0.5 + 0.5, h * 0.5 + 0.5)
+        center = (w * 0.5 - 0.5, h * 0.5 - 0.5)
         M = self._get_inverse_affine_matrix(center, *params)
         M = np.array(M).reshape((2, 3))
 
         for key in self.keys:
+            # print(key)
+            # print(M)
             results[key] = cv2.warpAffine(
                 results[key],
                 M, (w, h),

--- a/mmedit/datasets/pipelines/augmentation.py
+++ b/mmedit/datasets/pipelines/augmentation.py
@@ -447,6 +447,10 @@ class RandomAffine:
         else:
             shear = 0.0
 
+        # Because `flip` is used as a multiplier in line 479 and 480,
+        # so -1 stands for flip and 1 stands for no flip. Thus `flip`
+        # should be an 'inverse' flag as the result of the comparison.
+        # See https://github.com/open-mmlab/mmediting/pull/799 for more detail
         flip = (np.random.rand(2) > flip_ratio).astype(np.int32) * 2 - 1
 
         return angle, translations, scale, shear, flip

--- a/mmedit/datasets/pipelines/augmentation.py
+++ b/mmedit/datasets/pipelines/augmentation.py
@@ -447,7 +447,7 @@ class RandomAffine:
         else:
             shear = 0.0
 
-        flip = (np.random.rand(2) < flip_ratio).astype(np.int32) * 2 - 1
+        flip = (np.random.rand(2) > flip_ratio).astype(np.int32) * 2 - 1
 
         return angle, translations, scale, shear, flip
 

--- a/tests/test_data/test_pipelines/test_augmentation.py
+++ b/tests/test_data/test_pipelines/test_augmentation.py
@@ -265,7 +265,31 @@ class TestAugmentations:
 
         target_keys = ['fg', 'alpha']
 
+        # Test identical transformation
+        alpha = np.random.rand(4, 4).astype(np.float32)
+        fg = np.random.rand(4, 4).astype(np.float32)
+        results = dict(alpha=alpha, fg=fg)
+        random_affine = RandomAffine(['fg', 'alpha'],
+                                     degrees=0, flip_ratio=0.0)
+        random_affine_results = random_affine(results)
+        assert np.allclose(alpha, random_affine_results['alpha'])
+        assert np.allclose(fg, random_affine_results['fg'])
+
+        # Test flip in both direction
+        alpha = np.random.rand(4, 4).astype(np.float32)
+        fg = np.random.rand(4, 4).astype(np.float32)
+        results = dict(alpha=alpha, fg=fg)
+        # print(results)
+        random_affine = RandomAffine(['fg', 'alpha'],
+                                     degrees=0, flip_ratio=1.0)
+        random_affine_results = random_affine(results)
+        # print(random_affine_results)
+        # print(results)
+        assert np.allclose(alpha[::-1, ::-1], random_affine_results['alpha'])
+        assert np.allclose(fg[::-1, ::-1], random_affine_results['fg'])
+
         # test random affine with different valid setting combinations
+        # only shape are tested
         alpha = np.random.rand(240, 320).astype(np.float32)
         fg = np.random.rand(240, 320).astype(np.float32)
         results = dict(alpha=alpha, fg=fg)

--- a/tests/test_data/test_pipelines/test_augmentation.py
+++ b/tests/test_data/test_pipelines/test_augmentation.py
@@ -279,12 +279,9 @@ class TestAugmentations:
         alpha = np.random.rand(4, 4).astype(np.float32)
         fg = np.random.rand(4, 4).astype(np.float32)
         results = dict(alpha=alpha, fg=fg)
-        # print(results)
         random_affine = RandomAffine(['fg', 'alpha'],
                                      degrees=0, flip_ratio=1.0)
         random_affine_results = random_affine(results)
-        # print(random_affine_results)
-        # print(results)
         assert np.allclose(alpha[::-1, ::-1], random_affine_results['alpha'])
         assert np.allclose(fg[::-1, ::-1], random_affine_results['fg'])
 


### PR DESCRIPTION
original: `flip_ratio=1.` means always no flip and `flip_ratio=0.` means always flip
after:      `flip_ratio=1.` means always flip and `flip_ratio=0.` means always no flip