### PR TITLE
[Fix] Update preprocess_div2k_dataset.py

### DIFF
--- a/tools/data/super-resolution/div2k/preprocess_div2k_dataset.py
+++ b/tools/data/super-resolution/div2k/preprocess_div2k_dataset.py
@@ -351,14 +351,15 @@ def parse_args():
         formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     parser.add_argument('--data-root', help='dataset root')
     parser.add_argument(
-        '--scales', nargs='*', default=[2, 3, 4], help='scale factor list')
+        '--scales', nargs='*', default=[2, 3, 4], type=int, help='scale factor list')
     parser.add_argument(
         '--crop-size',
         nargs='?',
         default=480,
+        type=int,
         help='cropped size for HR images')
     parser.add_argument(
-        '--step', nargs='?', default=240, help='step size for HR images')
+        '--step', nargs='?', default=240, type=int, help='step size for HR images')
     parser.add_argument(
         '--thresh-size',
         nargs='?',

--- a/tools/data/super-resolution/div2k/preprocess_div2k_dataset.py
+++ b/tools/data/super-resolution/div2k/preprocess_div2k_dataset.py
@@ -351,7 +351,11 @@ def parse_args():
         formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     parser.add_argument('--data-root', help='dataset root')
     parser.add_argument(
-        '--scales', nargs='*', default=[2, 3, 4], type=int, help='scale factor list')
+        '--scales',
+        nargs='*',
+        default=[2, 3, 4],
+        type=int,
+        help='scale factor list')
     parser.add_argument(
         '--crop-size',
         nargs='?',
@@ -359,7 +363,11 @@ def parse_args():
         type=int,
         help='cropped size for HR images')
     parser.add_argument(
-        '--step', nargs='?', default=240, type=int, help='step size for HR images')
+        '--step',
+        nargs='?',
+        default=240,
+        type=int,
+        help='step size for HR images')
     parser.add_argument(
         '--thresh-size',
         nargs='?',


### PR DESCRIPTION
when I run follow code to prepare my customed dataset.
```
python custom/tools/data/super-resolution/div2k/preprocess_div2k_dataset.py \
       --data-root data/91-images \
       --scales 2 3 4 \
       --crop-size 33 \
       --step 14
```
a error occured as follows:

> mkdir data/91-images/DIV2K_train_HR_sub ...
> [                                                  ] 0/91, elapsed: 0s, ETA:All processes done.
> Traceback (most recent call last):
>   File "custom/tools/data/super-resolution/div2k/preprocess_div2k_dataset.py", line 390, in <module>
>     main_extract_subimages(args)
>   File "custom/tools/data/super-resolution/div2k/preprocess_div2k_dataset.py", line 69, in main_extract_subimages
>     opt['step'] = args.step // scale
> TypeError: unsupported operand type(s) for //: 'str' and 'int'

I think step, scale and crop-size should be int type, not default str type.

So I specified the input data type in parser.add_argument().

