### PR TITLE
[Docs] Fix Y/GRB mistake in EDSR README

### DIFF
--- a/configs/restorers/edsr/README.md
+++ b/configs/restorers/edsr/README.md
@@ -17,7 +17,7 @@ Recent research on super-resolution has progressed with the development of deep 
 
 ## Results and models
 
-Evaluated on Y channels, `scale` pixels in each border are cropped before evaluation.
+Evaluated on RGB channels, `scale` pixels in each border are cropped before evaluation.
 The metrics are `PSNR / SSIM` .
 
 |                                         Method                                         |       Set5       |      Set14       |      DIV2K       |                                                                                                                   Download                                                                                                                    |


### PR DESCRIPTION
The EDSR is evaluated in **RGB** channels, but `README` in EN says ''Evaluated on Y channels''.