### PR TITLE
[Improve] Add `--cfg-options` in train/test scripts

### DIFF
--- a/docs/en/getting_started.md
+++ b/docs/en/getting_started.md
@@ -67,6 +67,7 @@ You can check [slurm_test.sh](https://github.com/open-mmlab/mmediting/blob/maste
 - `--save-path`: Specify the path to store edited images. If not given, the images will not be saved.
 - `--seed`: Random seed during testing. This argument is used for fixed results in some tasks such as inpainting.
 - `--deterministic`: Related to `--seed`, this argument decides whether to set deterministic options for CUDNN backend. If specified, it will set `torch.backends.cudnn.deterministic` to True and `torch.backends.cudnn.benchmark` to False.
+- `--cfg-options`: If specified, the key-value pair optional cfg will be merged into config file.
 
 Note: Currently, we do NOT use `--eval` argument like [MMDetection](https://github.com/open-mmlab/mmdetection) to specify evaluation metrics. The evaluation metrics are given in the config files (see [config.md](config.md)).
 
@@ -167,6 +168,7 @@ Optional arguments are:
 - `--no-validate` (**not suggested**): By default, the codebase will perform evaluation every k iterations during the training. To disable this behavior, use `--no-validate`.
 - `--work-dir ${WORK_DIR}`: Override the working directory specified in the config file.
 - `--resume-from ${CHECKPOINT_FILE}`: Resume from a previous checkpoint file.
+- `--cfg-options`: If specified, the key-value pair optional cfg will be merged into config file.
 
 Difference between `resume-from` and `load-from`:
 `resume-from` loads both the model weights and optimizer status, and the iteration is also inherited from the specified checkpoint. It is usually used for resuming the training process that is interrupted accidentally.

--- a/docs/en/quick_run.md
+++ b/docs/en/quick_run.md
@@ -49,6 +49,7 @@ You can check [slurm_test.sh](https://github.com/open-mmlab/mmediting/blob/maste
 - `--save-path`: Specify the path to store edited images. If not given, the images will not be saved.
 - `--seed`: Random seed during testing. This argument is used for fixed results in some tasks such as inpainting.
 - `--deterministic`: Related to `--seed`, this argument decides whether to set deterministic options for CUDNN backend. If specified, it will set `torch.backends.cudnn.deterministic` to True and `torch.backends.cudnn.benchmark` to False.
+- `--cfg-options`: If specified, the key-value pair optional cfg will be merged into config file.
 
 Note: Currently, we do NOT use `--eval` argument like [MMDetection](https://github.com/open-mmlab/mmdetection) to specify evaluation metrics. The evaluation metrics are given in the config files (see [config.md](config.md)).
 
@@ -77,6 +78,7 @@ Optional arguments are:
 - `--no-validate` (**not suggested**): By default, the codebase will perform evaluation every k iterations during the training. To disable this behavior, use `--no-validate`.
 - `--work-dir ${WORK_DIR}`: Override the working directory specified in the config file.
 - `--resume-from ${CHECKPOINT_FILE}`: Resume from a previous checkpoint file.
+- `--cfg-options`: If specified, the key-value pair optional cfg will be merged into config file.
 
 Difference between `resume-from` and `load-from`:
 `resume-from` loads both the model weights and optimizer status, and the iteration is also inherited from the specified checkpoint. It is usually used for resuming the training process that is interrupted accidentally.

--- a/docs/zh_cn/getting_started.md
+++ b/docs/zh_cn/getting_started.md
@@ -66,6 +66,7 @@ GPUS=8 ./tools/slurm_test.sh dev test configs/example_config.py work_dirs/exampl
 - `--save-path`: 指定一个路径来存储编辑过的图片。如果没有被指定，图片将不会被存储。
 - `--seed`: 测试过程中的随机种子。这个参数是用来固定输出结果的。
 - `--deterministic`: 与 `--seed` 相关，这个参数决定了是否设置对于 CUDNN 的决定性选项。如果被指定了，`torch.backends.cudnn.deterministic` 将被设为 True，并且 `torch.backends.cudnn.benchmark` 将被设为 False。
+- `--cfg-options`:  如果指明，这里的键值对将会被合并到配置文件中。
 
 注：当前，我们不支持像 MMDetection 一样用 --eval 参数来指定评测指标。在 MMEditing 中，我们在配置文件中指定评测指标（详情参考：[config.md](config.md)）。
 
@@ -165,7 +166,7 @@ evaluation = dict(interval=1e4, by_epoch=False)  # 这样的话模型就会每 1
 - `--no-validate` (**不建议采用**): 我们默认会每 k 步就进行评测。如果需要关闭这个功能，可以使用 `--no-validate` 参数。
 - `--work-dir ${WORK_DIR}`: 重写在配置文件中指定的工作目录。
 - `--resume-from ${CHECKPOINT_FILE}`: 从之前的模型权重文件中重启训练。
-
+- `--cfg-options`:  如果指明，这里的键值对将会被合并到配置文件中。
 
 `resume-from` 和 `load-from` 之间的区别:
 `resume-from` 会加载模型参数、优化的状态量以及特定 checkpoint 里面的训练 iteration 数。这个参数通常会被用来重启被意外打断的训练过程。

--- a/docs/zh_cn/quick_run.md
+++ b/docs/zh_cn/quick_run.md
@@ -50,6 +50,7 @@ GPUS=8 ./tools/slurm_test.sh dev test configs/example_config.py work_dirs/exampl
 - `--save-path`: 指定存储编辑图像的路径。 如果没有给出，图像将不会被保存。
 - `--seed`: 测试期间的随机种子。 此参数用于固定某些任务中的结果，例如*修复*。
 - `--deterministic`: 与 `--seed` 相关，此参数决定是否为 CUDNN 后端设置确定性的选项。如果指定该参数，会将 `torch.backends.cudnn.deterministic` 设置为 `True`，将 `torch.backends.cudnn.benchmark` 设置为 `False`。
+- `--cfg-options`:  如果指明，这里的键值对将会被合并到配置文件中。
 
 注：目前，我们不使用像 [MMDetection](https://github.com/open-mmlab/mmdetection) 那样的 `--eval` 参数来指定评估指标。 评估指标在配置文件中给出（参见 [config.md](config.md)）。
 
@@ -77,6 +78,7 @@ evaluation = dict(interval=1e4, by_epoch=False)  # 每一万次迭代进行一�
 - `--no-validate` (**不建议**): 默认情况下，代码库将在训练期间每 k 次迭代执行一次评估。若要禁用此行为，请使用 `--no-validate`。
 - `--work-dir ${WORK_DIR}`: 覆盖配置文件中指定的工作目录。
 - `--resume-from ${CHECKPOINT_FILE}`: 从已有的模型权重文件恢复。
+- `--cfg-options`:  如果指明，这里的键值对将会被合并到配置文件中。
 
 `resume-from` 和 `load-from` 之间的区别：
 `resume-from` 加载模型权重和优化器状态，迭代也从指定的检查点继承。 它通常用于恢复意外中断的训练过程。

--- a/tools/test.py
+++ b/tools/test.py
@@ -4,6 +4,7 @@ import os
 
 import mmcv
 import torch
+from mmcv import Config, DictAction
 from mmcv.parallel import MMDataParallel
 from mmcv.runner import get_dist_info, init_dist, load_checkpoint
 
@@ -35,6 +36,16 @@ def parse_args():
         help='path to store images and if not given, will not save image')
     parser.add_argument('--tmpdir', help='tmp dir for writing some results')
     parser.add_argument(
+        '--cfg-options',
+        nargs='+',
+        action=DictAction,
+        help='override some settings in the used config, the key-value pair '
+        'in xxx=yyy format will be merged into config file. If the value to '
+        'be overwritten is a list, it should be like key="[a,b]" or key=a,b '
+        'It also allows nested list/tuple values, e.g. key="[(a,b),(c,d)]" '
+        'Note that the quotation marks are necessary and that no white space '
+        'is allowed.')
+    parser.add_argument(
         '--launcher',
         choices=['none', 'pytorch', 'slurm', 'mpi'],
         default='none',
@@ -49,7 +60,10 @@ def parse_args():
 def main():
     args = parse_args()
 
-    cfg = mmcv.Config.fromfile(args.config)
+    cfg = Config.fromfile(args.config)
+
+    if args.cfg_options is not None:
+        cfg.merge_from_dict(args.cfg_options)
 
     # set multi-process settings
     setup_multi_processes(cfg)

--- a/tools/train.py
+++ b/tools/train.py
@@ -8,7 +8,7 @@ import time
 import mmcv
 import torch
 import torch.distributed as dist
-from mmcv import Config
+from mmcv import Config, DictAction
 from mmcv.runner import init_dist
 
 from mmedit import __version__
@@ -44,6 +44,16 @@ def parse_args():
         action='store_true',
         help='whether to set deterministic options for CUDNN backend.')
     parser.add_argument(
+        '--cfg-options',
+        nargs='+',
+        action=DictAction,
+        help='override some settings in the used config, the key-value pair '
+        'in xxx=yyy format will be merged into config file. If the value to '
+        'be overwritten is a list, it should be like key="[a,b]" or key=a,b '
+        'It also allows nested list/tuple values, e.g. key="[(a,b),(c,d)]" '
+        'Note that the quotation marks are necessary and that no white space '
+        'is allowed.')
+    parser.add_argument(
         '--launcher',
         choices=['none', 'pytorch', 'slurm', 'mpi'],
         default='none',
@@ -64,6 +74,9 @@ def main():
     args = parse_args()
 
     cfg = Config.fromfile(args.config)
+
+    if args.cfg_options is not None:
+        cfg.merge_from_dict(args.cfg_options)
 
     # set multi-process settings
     setup_multi_processes(cfg)


### PR DESCRIPTION
https://github.com/open-mmlab/mmdetection/blob/3e2693151add9b5d6db99b944da020cba837266b/tools/train.py#L72

Sometimes we want to use a custom runtime configuration for a given configuration file.
This feature is already supported in other mm-frameworks, so I added it.