### PR TITLE
[Enhance] Support non-zero frame index for `SRFolderVideoDataset` & Fix Typos

### DIFF
--- a/mmedit/datasets/comp1k_dataset.py
+++ b/mmedit/datasets/comp1k_dataset.py
@@ -54,7 +54,7 @@ class AdobeComp1kDataset(BaseMattingDataset):
     """
 
     def load_annotations(self):
-        """Load annoations for Adobe Composition-1k dataset.
+        """Load annotations for Adobe Composition-1k dataset.
 
         It loads image paths from json file.
 

--- a/mmedit/datasets/pipelines/__init__.py
+++ b/mmedit/datasets/pipelines/__init__.py
@@ -31,7 +31,7 @@ __all__ = [
     'RandomLoadResizeBg', 'Compose', 'ImageToTensor', 'ToTensor',
     'GetMaskedImage', 'BinarizeImage', 'Flip', 'Pad', 'RandomAffine',
     'RandomJitter', 'ColorJitter', 'RandomMaskDilation', 'RandomTransposeHW',
-    'Resize', 'RandomResizedCrop', 'CenterCrop', 'Crop', 'CropAroundCenter',
+    'Resize', 'RandomResizedCrop', 'Crop', 'CropAroundCenter',
     'CropAroundUnknown', 'ModCrop', 'PairedRandomCrop', 'Normalize',
     'RescaleToZeroOne', 'GenerateTrimap', 'MergeFgAndBg', 'CompositeFg',
     'TemporalReverse', 'LoadImageFromFileList', 'GenerateFrameIndices',
@@ -43,5 +43,5 @@ __all__ = [
     'CropLike', 'GenerateHeatmap', 'MATLABLikeResize', 'CopyValues',
     'Quantize', 'RandomBlur', 'RandomJPEGCompression', 'RandomNoise',
     'DegradationsWithShuffle', 'RandomResize', 'UnsharpMasking',
-    'RandomVideoCompression', 'CropSequence'
+    'RandomVideoCompression',
 ]

--- a/mmedit/datasets/pipelines/__init__.py
+++ b/mmedit/datasets/pipelines/__init__.py
@@ -43,5 +43,5 @@ __all__ = [
     'CropLike', 'GenerateHeatmap', 'MATLABLikeResize', 'CopyValues',
     'Quantize', 'RandomBlur', 'RandomJPEGCompression', 'RandomNoise',
     'DegradationsWithShuffle', 'RandomResize', 'UnsharpMasking',
-    'RandomVideoCompression',
+    'RandomVideoCompression'
 ]

--- a/mmedit/datasets/sr_annotation_dataset.py
+++ b/mmedit/datasets/sr_annotation_dataset.py
@@ -53,7 +53,7 @@ class SRAnnotationDataset(BaseSRDataset):
         self.data_infos = self.load_annotations()
 
     def load_annotations(self):
-        """Load annoations for SR dataset.
+        """Load annotations for SR dataset.
 
         It loads the LQ and GT image path from the annotation file.
         Each line in the annotation file contains the image names and

--- a/mmedit/datasets/sr_facial_landmark_dataset.py
+++ b/mmedit/datasets/sr_facial_landmark_dataset.py
@@ -44,7 +44,7 @@ class SRFacialLandmarkDataset(BaseSRDataset):
         self.data_infos = self.load_annotations()
 
     def load_annotations(self):
-        """Load annoations for SR dataset.
+        """Load annotations for SR dataset.
 
         Annotation file is a `npy` file, which contains a list of dict.
 

--- a/mmedit/datasets/sr_folder_dataset.py
+++ b/mmedit/datasets/sr_folder_dataset.py
@@ -63,7 +63,7 @@ class SRFolderDataset(BaseSRDataset):
         self.data_infos = self.load_annotations()
 
     def load_annotations(self):
-        """Load annoations for SR dataset.
+        """Load annotations for SR dataset.
 
         It loads the LQ and GT image path from folders.
 

--- a/mmedit/datasets/sr_folder_gt_dataset.py
+++ b/mmedit/datasets/sr_folder_gt_dataset.py
@@ -50,7 +50,7 @@ class SRFolderGTDataset(BaseSRDataset):
         self.data_infos = self.load_annotations()
 
     def load_annotations(self):
-        """Load annoations for SR dataset.
+        """Load annotations for SR dataset.
 
         It loads the GT image path from folder.
 

--- a/mmedit/datasets/sr_folder_multiple_gt_dataset.py
+++ b/mmedit/datasets/sr_folder_multiple_gt_dataset.py
@@ -92,7 +92,7 @@ class SRFolderMultipleGTDataset(BaseSRDataset):
         return data_infos
 
     def load_annotations(self):
-        """Load annoations for the dataset.
+        """Load annotations for the dataset.
 
         Returns:
             list[dict]: Returned list of dicts for paired paths of LQ and GT.

--- a/mmedit/datasets/sr_folder_ref_dataset.py
+++ b/mmedit/datasets/sr_folder_ref_dataset.py
@@ -85,7 +85,7 @@ class SRFolderRefDataset(BaseSRDataset):
         self.data_infos = self.load_annotations()
 
     def load_annotations(self):
-        """Load annoations for SR dataset.
+        """Load annotations for SR dataset.
 
         It loads the ref, LQ and GT image path from folders.
 

--- a/mmedit/datasets/sr_folder_video_dataset.py
+++ b/mmedit/datasets/sr_folder_video_dataset.py
@@ -110,7 +110,7 @@ class SRFolderVideoDataset(BaseSRDataset):
         return data_infos
 
     def load_annotations(self):
-        """Load annoations for the dataset.
+        """Load annotations for the dataset.
 
         Returns:
             list[dict]: A list of dicts for paired paths and other information.

--- a/mmedit/datasets/sr_folder_video_dataset.py
+++ b/mmedit/datasets/sr_folder_video_dataset.py
@@ -67,6 +67,7 @@ class SRFolderVideoDataset(BaseSRDataset):
                  scale,
                  ann_file=None,
                  filename_tmpl='{:08d}',
+                 start_idx=0,
                  metric_average_mode='clip',
                  test_mode=True):
         super().__init__(pipeline, scale, test_mode)
@@ -83,6 +84,7 @@ class SRFolderVideoDataset(BaseSRDataset):
         self.num_input_frames = num_input_frames
         self.ann_file = ann_file
         self.filename_tmpl = filename_tmpl
+        self.start_idx = start_idx
         self.metric_average_mode = metric_average_mode
 
         self.data_infos = self.load_annotations()
@@ -131,7 +133,7 @@ class SRFolderVideoDataset(BaseSRDataset):
             max_frame_num = len(list(mmcv.utils.scandir(seq_dir)))
             self.folders[sequence] = max_frame_num
 
-            for i in range(0, max_frame_num):
+            for i in range(self.start_idx, max_frame_num + self.start_idx):
                 data_infos.append(
                     dict(
                         lq_path=self.lq_folder,

--- a/mmedit/datasets/sr_folder_video_dataset.py
+++ b/mmedit/datasets/sr_folder_video_dataset.py
@@ -51,6 +51,8 @@ class SRFolderVideoDataset(BaseSRDataset):
             that all sequences in the folder is used. Default: None.
         filename_tmpl (str): Template for each filename. Note that the
             template excludes the file extension. Default: '{:08d}'.
+        start_idx (int): The index corresponds to the first frame
+            in the sequence. Default: 0.
         metric_average_mode (str): The way to compute the average metric.
             If 'clip', we first compute an average value for each clip, and
             then average the values from different clips. If 'all', we

--- a/mmedit/datasets/sr_lmdb_dataset.py
+++ b/mmedit/datasets/sr_lmdb_dataset.py
@@ -75,7 +75,7 @@ class SRLmdbDataset(BaseSRDataset):
         self.data_infos = self.load_annotations()
 
     def load_annotations(self):
-        """Load annoations for SR dataset.
+        """Load annotations for SR dataset.
 
         It loads the LQ and GT image path from the ``meta_info.txt`` in the
         LMDB files.

--- a/mmedit/datasets/sr_reds_dataset.py
+++ b/mmedit/datasets/sr_reds_dataset.py
@@ -57,7 +57,7 @@ class SRREDSDataset(BaseSRDataset):
         self.data_infos = self.load_annotations()
 
     def load_annotations(self):
-        """Load annoations for REDS dataset.
+        """Load annotations for REDS dataset.
 
         Returns:
             list[dict]: A list of dicts for paired paths and other information.

--- a/mmedit/datasets/sr_reds_multiple_gt_dataset.py
+++ b/mmedit/datasets/sr_reds_multiple_gt_dataset.py
@@ -49,7 +49,7 @@ class SRREDSMultipleGTDataset(BaseSRDataset):
         self.data_infos = self.load_annotations()
 
     def load_annotations(self):
-        """Load annoations for REDS dataset.
+        """Load annotations for REDS dataset.
 
         Returns:
             list[dict]: A list of dicts for paired paths and other information.

--- a/mmedit/datasets/sr_vid4_dataset.py
+++ b/mmedit/datasets/sr_vid4_dataset.py
@@ -74,7 +74,7 @@ class SRVid4Dataset(BaseSRDataset):
         self.data_infos = self.load_annotations()
 
     def load_annotations(self):
-        """Load annoations for Vid4 dataset.
+        """Load annotations for Vid4 dataset.
         Returns:
             list[dict]: A list of dicts for paired paths and other information.
         """

--- a/mmedit/datasets/sr_vimeo90k_dataset.py
+++ b/mmedit/datasets/sr_vimeo90k_dataset.py
@@ -54,7 +54,7 @@ class SRVimeo90KDataset(BaseSRDataset):
         self.data_infos = self.load_annotations()
 
     def load_annotations(self):
-        """Load annoations for VimeoK dataset.
+        """Load annotations for VimeoK dataset.
 
         Returns:
             list[dict]: A list of dicts for paired paths and other information.

--- a/mmedit/datasets/sr_vimeo90k_multiple_gt_dataset.py
+++ b/mmedit/datasets/sr_vimeo90k_multiple_gt_dataset.py
@@ -56,7 +56,7 @@ class SRVimeo90KMultipleGTDataset(BaseSRDataset):
         self.data_infos = self.load_annotations()
 
     def load_annotations(self):
-        """Load annoations for Vimeo-90K dataset.
+        """Load annotations for Vimeo-90K dataset.
 
         Returns:
             list[dict]: A list of dicts for paired paths and other information.

--- a/mmedit/datasets/vfi_vimeo90k_dataset.py
+++ b/mmedit/datasets/vfi_vimeo90k_dataset.py
@@ -37,7 +37,7 @@ class VFIVimeo90KDataset(BaseVFIDataset):
         self.data_infos = self.load_annotations()
 
     def load_annotations(self):
-        """Load annoations for VimeoK dataset.
+        """Load annotations for VimeoK dataset.
 
         Returns:
             list[dict]: A list of dicts for paired paths and other information.

--- a/mmedit/models/backbones/sr_backbones/basicvsr_net.py
+++ b/mmedit/models/backbones/sr_backbones/basicvsr_net.py
@@ -125,7 +125,7 @@ class BasicVSRNet(nn.Module):
         # compute optical flow
         flows_forward, flows_backward = self.compute_flow(lrs)
 
-        # backward-time propgation
+        # backward-time propagation
         outputs = []
         feat_prop = lrs.new_zeros(n, self.mid_channels, h, w)
         for i in range(t - 1, -1, -1):

--- a/mmedit/models/backbones/sr_backbones/basicvsr_pp.py
+++ b/mmedit/models/backbones/sr_backbones/basicvsr_pp.py
@@ -159,7 +159,7 @@ class BasicVSRPlusPlus(nn.Module):
             feats dict(list[tensor]): Features from previous branches. Each
                 component is a list of tensors with shape (n, c, h, w).
             flows (tensor): Optical flows with shape (n, t - 1, 2, h, w).
-            module_name (str): The name of the propgation branches. Can either
+            module_name (str): The name of the propagation branches. Can either
                 be 'backward_1', 'forward_1', 'backward_2', 'forward_2'.
 
         Return:
@@ -244,7 +244,7 @@ class BasicVSRPlusPlus(nn.Module):
         Args:
             lqs (tensor): Input low quality (LQ) sequence with
                 shape (n, t, c, h, w).
-            feats (dict): The features from the propgation branches.
+            feats (dict): The features from the propagation branches.
 
         Returns:
             Tensor: Output HR sequence with shape (n, t, c, 4h, 4w).
@@ -331,7 +331,7 @@ class BasicVSRPlusPlus(nn.Module):
             f'but got {h} and {w}.')
         flows_forward, flows_backward = self.compute_flow(lqs_downsample)
 
-        # feature propgation
+        # feature propagation
         for iter_ in [1, 2]:
             for direction in ['backward', 'forward']:
                 module = f'{direction}_{iter_}'

--- a/mmedit/models/backbones/sr_backbones/iconvsr.py
+++ b/mmedit/models/backbones/sr_backbones/iconvsr.py
@@ -205,7 +205,7 @@ class IconVSR(nn.Module):
         flows_forward, flows_backward = self.compute_flow(lrs)
         feats_refill = self.compute_refill_features(lrs, keyframe_idx)
 
-        # backward-time propgation
+        # backward-time propagation
         outputs = []
         feat_prop = lrs.new_zeros(n, self.mid_channels, h, w)
         for i in range(t - 1, -1, -1):


### PR DESCRIPTION
## Polish

1. Correct "annoations" to "annotations".
2. Correct "propgation" to "propagation".
3. Remove undefined functions in `mmedit/datasets/pipelines/__init__.py`.

## Improvement

Some sequences may start from a frame index other than 0.
If without annotation files, `SRFolderVideoDataset` cannot process these sequences correctly; sequences must start from 0.
But in many cases, we use our own data-sets to train video SR methods such as EDVR, and the sequences in these data-sets may start from a frame index other than 0.