### PR TITLE
[Enhancement] Support rerun failed or canceled jobs in `train_benchmark.py`

### DIFF
--- a/.dev_scripts/README.md
+++ b/.dev_scripts/README.md
@@ -184,7 +184,34 @@ python .dev_scripts/train_benchmark.py mm_lol \
 
 Specifically, you need to enable `--skip`, and specify the list of models to skip by `--skip-list`
 
-## Automatically check links
+## 7. Train failed or canceled jobs
+
+If you want to rerun failed or canceled jobs in the last run, you can combine `--rerun` flag with `--rerun-failure` and `--rerun-cancel` flags.
+
+For example, the log file of the last run is `train-20221009-211904.log`, and now you want to rerun the failed jobs. You can use the following command:
+
+```bash
+python .dev_scripts/train_benchmark.py mm_lol \
+    --job-name RERUN \
+    --rerun train-20221009-211904.log \
+    --rerun-fail \
+    --run
+```
+
+We can combine `--rerun-fail` and `--rerun-cancel` with flag `---models` to rerun a **subset** of failed or canceled model.
+
+```bash
+python .dev_scripts/train_benchmark.py mm_lol \
+    --job-name RERUN \
+    --rerun train-20221009-211904.log \
+    --rerun-fail \
+    --models sagan \  # only rerun 'sagan' models in all failed tasks
+    --run
+```
+
+Specifically, `--rerun-fail` and `--rerun-cancel` can be used together to rerun both failed and cancaled jobs.
+
+## 8. Automatically check links
 
 Use the following script to check whether the links in documentations are valid:
 

--- a/.dev_scripts/job_watcher.py
+++ b/.dev_scripts/job_watcher.py
@@ -9,7 +9,7 @@ from pygments import formatters, highlight, lexers
 from pygments.util import ClassNotFound
 from simple_term_menu import TerminalMenu
 
-CACHE_DIR = '~/.task_watcher'
+CACHE_DIR = osp.join(osp.abspath('~'), '.task_watcher')
 
 
 def show_job_out(name, root, job_name_list):

--- a/.dev_scripts/utils.py
+++ b/.dev_scripts/utils.py
@@ -1,0 +1,118 @@
+import os
+import os.path as osp
+from typing import Tuple
+
+from rich import print as pprint
+from rich.table import Table
+
+
+def parse_job_list(job_list) -> Tuple[list, list]:
+    """Parse task name and job id from list. All elements in `job_list` must.
+
+    be formatted as `JOBID @ JOBNAME`.
+
+    Args:
+        job_list (list[str]): Job list.
+
+    Returns:
+        Tuple[list, list]: Job ID list and Job name list.
+    """
+    assert all([
+        ' @ ' in job for job in job_list
+    ]), ('Each line of job list must be formatted like \'JOBID @ JOBNAME\'.')
+    job_id_list, job_name_list = [], []
+    for job_info in job_list:
+        job_id, job_name = job_info.split(' @ ')
+        job_id_list.append(job_id)
+        job_name_list.append(job_name)
+    return job_id_list, job_name_list
+
+
+def parse_job_list_from_file(job_list_file: str) -> Tuple[list, list]:
+    """Parse job list from file and return a tuple contains list of job id and
+    job name.
+
+    Args:
+        job_list_file (str): The path to the file list.
+
+    Returns:
+        Tuple[list, list]: A tuple contains list of job id and job name.
+    """
+    if not osp.exists(job_list_file):
+        return False
+    with open(job_list_file, 'r') as file:
+        job_list = [job.strip() for job in file.readlines()]
+    return parse_job_list(job_list)
+
+
+def get_info_from_id(job_id: str) -> dict:
+    """Get the basic information of a job id with `swatch examine` command.
+
+    Args:
+        job_id (str): The ID of the job.
+
+    Returns:
+        dict: A dict contains information of the corresponding job id.
+    """
+    # NOTE: do not have exception handling here
+    info_stream = os.popen(f'swatch examine {job_id}')
+    info_str = [line.strip() for line in info_stream.readlines()]
+    status_info = info_str[2].split()
+    try:
+        status_dict = {
+            'JobID': status_info[0],
+            'JobName': status_info[1],
+            'Partition': status_info[2],
+            'NNodes': status_info[3],
+            'AllocCPUS': status_info[4],
+            'State': status_info[5]
+        }
+    except Exception:
+        print(job_id)
+        print(info_str)
+    return status_dict
+
+
+def filter_jobs(job_id_list: list,
+                job_name_list: list,
+                select: list = ['FAILED'],
+                show_table: bool = False,
+                table_name: str = 'Filter Results') -> Tuple[list, list]:
+    """Filter the job which status not belong to :attr:`select`.
+
+    Args:
+        job_id_list (list): The list of job ids.
+        job_name_list (list): The list of job names.
+        select (list, optional): Which kind of jobs will be selected.
+            Defaults to ['FAILED'].
+        show_table (bool, optional): Whether display the filter result in a
+            table. Defaults to False.
+        table_name (str, optional): The name of the table. Defaults to
+            'Filter Results'.
+
+    Returns:
+        Tuple[list]: A tuple contains selected job ids and job names.
+    """
+    # if ignore is not passed, return the original id list and name list
+    if not select:
+        return job_id_list, job_name_list
+    filtered_id_list, filtered_name_list = [], []
+    job_info_list = []
+    for id_, name_ in zip(job_id_list, job_name_list):
+        info = get_info_from_id(id_)
+        job_info_list.append(info)
+        if info['State'] in select:
+            filtered_id_list.append(id_)
+            filtered_name_list.append(name_)
+
+    if show_table:
+        filter_table = Table(title=table_name)
+        for field in ['Name', 'ID', 'State', 'Is Selected']:
+            filter_table.add_column(field)
+        for id_, name_, info_ in zip(job_id_list, job_name_list,
+                                     job_info_list):
+            selected = '[green]True' \
+                if info_['State'] in select else '[red]False'
+            filter_table.add_row(name_, id_, info_['State'], selected)
+        pprint(filter_table)
+    return filtered_id_list, filtered_name_list


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Support rerun failed or canceled jobs in the last run.

## Modification

1. Add a group of general functions for job log parsing
2. Support `--rerun-failure` and `--rerun-cancel` flags in `train_benchmark.py`
3. Bug of the wrong cache dir in `job_watcher.py` is fixed as well.

## Who can help? @ them here!

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

Please refers to [README.md](https://github.com/open-mmlab/mmediting/compare/dev-1.x...LeoXing1996:leoxing/regression?expand=1#diff-841aa9bffc1016e5b3591404a95cb2e41ea2ab100b54d233e75cf42b8e3cd762).

## Checklist

**Before PR**:

- [x] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmediting/blob/master/.github/CONTRIBUTING.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmediting/blob/master/.github/CONTRIBUTING.md) are used to fix the potential lint issues.
- [x] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [x] If the modification has potential influence on downstream or other related projects, this PR should be tested with some of those projects.
- [x] CLA has been signed and all committers have signed the CLA in this PR.
