### PR TITLE
[Bug Fixed] Correct the number of output channels of LFF in RDB

### DIFF
--- a/mmedit/models/backbones/sr_backbones/rdn.py
+++ b/mmedit/models/backbones/sr_backbones/rdn.py
@@ -51,7 +51,7 @@ class RDB(nn.Module):
         # local feature fusion
         self.lff = nn.Conv2d(
             in_channels + channel_growth * num_layers,
-            channel_growth,
+            in_channels,
             kernel_size=1)
 
     def forward(self, x):


### PR DESCRIPTION
## Motivation

When using the RDB, I found this bug.

The RDB adopts residual learning between `x` and `self.lff(self.layers(x))`. However, the channel number of `x` is `in_channels `, while the output channels of `self.lff` is `channel_growth`.

This bug did not cause error in the past because the default `channel_growth` of the RDN class is 64, which is not indicated in any config files of RDN. At the same time, all config files use `mid_channels=64`, which is equal to the `channel_growth`.

However, when someone uses the RDB class independently, this bug may cause error.

Issue: https://github.com/open-mmlab/mmediting/issues/1136

## Modification

I change the number of output channels of LFF from `channel_growth` to `in_channels`.

## Who can help? @ them here!

@plyfager

## Checklist

**Before PR**:

- [x] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmediting/blob/master/.github/CONTRIBUTING.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmediting/blob/master/.github/CONTRIBUTING.md) are used to fix the potential lint issues.
- [x] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [x] If the modification has potential influence on downstream or other related projects, this PR should be tested with some of those projects.
- [x] CLA has been signed and all committers have signed the CLA in this PR.
