### PR TITLE
[Bug] Change RDB output channels

### DIFF
--- a/mmedit/models/backbones/sr_backbones/rdn.py
+++ b/mmedit/models/backbones/sr_backbones/rdn.py
@@ -112,16 +112,15 @@ class RDN(nn.Module):
             mid_channels, mid_channels, kernel_size=3, padding=3 // 2)
 
         # residual dense blocks
-        self.rdbs = nn.ModuleList(
-            [RDB(self.mid_channels, self.channel_growth, self.num_layers)])
-        for _ in range(self.num_blocks - 1):
+        self.rdbs = nn.ModuleList()
+        for _ in range(self.num_blocks):
             self.rdbs.append(
-                RDB(self.channel_growth, self.channel_growth, self.num_layers))
+                RDB(self.mid_channels, self.channel_growth, self.num_layers))
 
         # global feature fusion
         self.gff = nn.Sequential(
             nn.Conv2d(
-                self.channel_growth * self.num_blocks,
+                self.mid_channels * self.num_blocks,
                 self.mid_channels,
                 kernel_size=1),
             nn.Conv2d(


### PR DESCRIPTION
I found more bugs about the RDN implementation after the PR https://github.com/open-mmlab/mmediting/pull/1292.

In the present version, `self.mid_channels` and `self.channel_growth` must be the same. Buggy codes:

https://github.com/open-mmlab/mmediting/blob/398572a2875c9a8f0f22059450056f055c88fca3/mmedit/models/backbones/sr_backbones/rdn.py#L114-L119

Explain: The first RDB outputs `self.mid_channels` channels (note that the output channel number of RDB must be the same with its input channel number, i.e., `self.mid_channels`). However, the second RDB is fed with `self.channel_growth` channels.

When `self.mid_channels != self.channel_growth`, the error occurs.

According to the RDN paper, the I/O channel numbers of all RDBs are `self.mid_channels`. As a result, the following GFF should be fed with `self.mid_channels * self.num_blocks` channels. Buggy codes:

https://github.com/open-mmlab/mmediting/blob/398572a2875c9a8f0f22059450056f055c88fca3/mmedit/models/backbones/sr_backbones/rdn.py#L121-L131

After this PR, `self.mid_channels` and `self.channel_growth` can be different. `self.mid_channels` is the parameter between RDBs, while `self.channel_growth` is the parameter inside each RDB.

Thank you.

@plyfager 
