### PR TITLE
[Doc] update docstring of RDN

### DIFF
--- a/mmedit/models/backbones/sr_backbones/rdn.py
+++ b/mmedit/models/backbones/sr_backbones/rdn.py
@@ -71,10 +71,16 @@ class RDN(nn.Module):
     """RDN model for single image super-resolution.
 
     Paper: Residual Dense Network for Image Super-Resolution
+    Official implementation: ''
 
     Adapted from 'https://github.com/yjn870/RDN-pytorch.git'
     'RDN-pytorch/blob/master/models.py'
     Copyright (c) 2021, JaeYun Yeo, under MIT License.
+    
+    Most of the implementation follows 'https://github.com/sanghyun-son/EDSR-PyTorch.git'
+    'EDSR-PyTorch/blob/master/src/model/rdn.py'
+    Copyright (c) 2017, sanghyun-son, under MIT license.
+    
 
     Args:
         in_channels (int): Channel number of inputs.

--- a/mmedit/models/backbones/sr_backbones/rdn.py
+++ b/mmedit/models/backbones/sr_backbones/rdn.py
@@ -75,11 +75,12 @@ class RDN(nn.Module):
     Adapted from 'https://github.com/yjn870/RDN-pytorch.git'
     'RDN-pytorch/blob/master/models.py'
     Copyright (c) 2021, JaeYun Yeo, under MIT License.
-    
-    Most of the implementation follows 'https://github.com/sanghyun-son/EDSR-PyTorch.git'
+
+    Most of the implementation follows the implementation in:
+    'https://github.com/sanghyun-son/EDSR-PyTorch.git'
     'EDSR-PyTorch/blob/master/src/model/rdn.py'
     Copyright (c) 2017, sanghyun-son, under MIT license.
-    
+
 
     Args:
         in_channels (int): Channel number of inputs.

--- a/mmedit/models/backbones/sr_backbones/rdn.py
+++ b/mmedit/models/backbones/sr_backbones/rdn.py
@@ -71,7 +71,6 @@ class RDN(nn.Module):
     """RDN model for single image super-resolution.
 
     Paper: Residual Dense Network for Image Super-Resolution
-    Official implementation: ''
 
     Adapted from 'https://github.com/yjn870/RDN-pytorch.git'
     'RDN-pytorch/blob/master/models.py'


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Currently, MMEditing supports RDN following https://github.com/yjn870/RDN-pytorch/blob/master/models.py#L21 , whose implementation is slightly different from the official implementation: https://github.com/sanghyun-son/EDSR-PyTorch

## Modification

Code has been fixed in https://github.com/open-mmlab/mmediting/pull/1292 and https://github.com/open-mmlab/mmediting/pull/1311
In this pull request, we add the official implementation in the docstring. 

## Who can help? @ them here!

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

**Before PR**:

- [ ] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmediting/blob/master/.github/CONTRIBUTING.md) to create this PR.
- [ ] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmediting/blob/master/.github/CONTRIBUTING.md) are used to fix the potential lint issues.
- [ ] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with some of those projects.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
