### PR TITLE
[Feature] Adopt mmeval's SSIM and SNR in mmediting

### DIFF
--- a/mmedit/evaluation/metrics/__init__.py
+++ b/mmedit/evaluation/metrics/__init__.py
@@ -14,8 +14,8 @@ from .ppl import PerceptualPathLength
 from .precision_and_recall import PrecisionAndRecall
 from .psnr import PSNR, psnr
 from .sad import SAD
-from .snr import SNR, snr
-from .ssim import SSIM, ssim
+from .snr import SNR
+from .ssim import SSIM
 from .swd import SlicedWassersteinDistance
 
 __all__ = [
@@ -24,9 +24,7 @@ __all__ = [
     'PSNR',
     'psnr',
     'SNR',
-    'snr',
     'SSIM',
-    'ssim',
     'MultiScaleStructureSimilarity',
     'FrechetInceptionDistance',
     'TransFID',

--- a/mmedit/evaluation/metrics/snr.py
+++ b/mmedit/evaluation/metrics/snr.py
@@ -1,30 +1,21 @@
 # Copyright (c) OpenMMLab. All rights reserved.
-from typing import Optional
+from typing import Optional, Sequence
 
-import numpy as np
+from mmeval import SNR as SNR_MMEVAL
 
 from mmedit.registry import METRICS
-from .base_sample_wise_metric import BaseSampleWiseMetric
-from .metrics_utils import img_transform
+from .metrics_utils import obtain_data
 
 
 @METRICS.register_module()
-class SNR(BaseSampleWiseMetric):
-    """Signal-to-Noise Ratio.
+class SNR(SNR_MMEVAL):
+    """Signal-to-Noise Ratio. A wrapper of :class:`mmeval.SNR`.
 
     Ref: https://en.wikipedia.org/wiki/Signal-to-noise_ratio
 
     Args:
-
         gt_key (str): Key of ground-truth. Default: 'gt_img'
         pred_key (str): Key of prediction. Default: 'pred_img'
-        collect_device (str): Device name used for collecting results from
-            different ranks during distributed training. Must be 'cpu' or
-            'gpu'. Defaults to 'cpu'.
-        prefix (str, optional): The prefix that will be added in the metric
-            names to disambiguate homonymous metrics of different evaluators.
-            If prefix is not provided in the argument, self.default_prefix
-            will be used instead. Default: None
         crop_border (int): Cropped pixels in each edges of an image. These
             pixels are not involved in the SNR calculation. Default: 0.
         input_order (str): Whether the input order is 'HWC' or 'CHW'.
@@ -33,6 +24,11 @@ class SNR(BaseSampleWiseMetric):
             If None, the images are not altered. When computing for 'Y',
             the images are assumed to be in BGR order. Options are 'Y' and
             None. Default: None.
+        channel_order (str): The channel order of image. Default: 'rgb'.
+        prefix (str, optional): The prefix that will be added in the metric
+            names to disambiguate homonymous metrics of different evaluators.
+            If prefix is not provided in the argument, self.default_prefix
+            will be used instead. Default: None
 
     Metrics:
         - SNR (float): Signal-to-Noise Ratio
@@ -43,88 +39,60 @@ class SNR(BaseSampleWiseMetric):
     def __init__(self,
                  gt_key: str = 'gt_img',
                  pred_key: str = 'pred_img',
-                 collect_device: str = 'cpu',
-                 prefix: Optional[str] = None,
-                 crop_border=0,
                  input_order='CHW',
-                 convert_to=None) -> None:
-        super().__init__(
-            gt_key=gt_key,
-            pred_key=pred_key,
-            mask_key=None,
-            collect_device=collect_device,
-            prefix=prefix)
+                 crop_border=0,
+                 convert_to=None,
+                 channel_order: str = 'rgb',
+                 prefix: Optional[str] = None,
+                 scaling: float = 1,
+                 **kwargs) -> None:
+        super().__init__(input_order, convert_to, crop_border, channel_order,
+                         **kwargs)
 
-        self.crop_border = crop_border
-        self.input_order = input_order
-        self.convert_to = convert_to
+        self.gt_key = gt_key
+        self.pred_key = pred_key
+        self.prefix = prefix
+        self.scaling = scaling
 
-    def process_image(self, gt, pred, mask):
-        """Process an image.
+    def process(self, data_batch: Sequence[dict],
+                data_samples: Sequence[dict]) -> None:
+        """Process one batch of data and predictions.
 
         Args:
-            gt (Torch | np.ndarray): GT image.
-            pred (Torch | np.ndarray): Pred image.
-            mask (Torch | np.ndarray): Mask of evaluation.
-        Returns:
-            np.ndarray: SNR result.
+            data_batch (Sequence[dict]): A batch of data
+                from the dataloader.
+            predictions (Sequence[dict]): A batch of outputs from
+                the model.
         """
 
-        return snr(
-            gt=gt,
-            pred=pred,
-            crop_border=self.crop_border,
-            input_order=self.input_order,
-            convert_to=self.convert_to,
-            channel_order=self.channel_order)
+        for data in data_samples:
+            prediction = data['output']
 
+            channel_order = 'rgb'
+            metainfo = data
+            if 'gt_channel_order' in metainfo:
+                channel_order = metainfo['gt_channel_order']
+            elif 'img_channel_order' in metainfo:
+                channel_order = metainfo['img_channel_order']
 
-def snr(gt,
-        pred,
-        crop_border=0,
-        input_order='HWC',
-        convert_to=None,
-        channel_order='rgb'):
-    """Calculate PSNR (Peak Signal-to-Noise Ratio).
+            gt = obtain_data(data, self.gt_key)
+            pred = obtain_data(prediction, self.pred_key)
 
-    Ref: https://en.wikipedia.org/wiki/Peak_signal-to-noise_ratio
+            gt = [sample for sample in gt]
+            pred = [sample for sample in pred]
 
-    Args:
-        gt (ndarray): Images with range [0, 255].
-        pred (ndarray): Images with range [0, 255].
-        crop_border (int): Cropped pixels in each edges of an image. These
-            pixels are not involved in the PSNR calculation. Default: 0.
-        input_order (str): Whether the input order is 'HWC' or 'CHW'.
-            Default: 'HWC'.
-        convert_to (str): Whether to convert the images to other color models.
-            If None, the images are not altered. When computing for 'Y',
-            the images are assumed to be in BGR order. Options are 'Y' and
-            None. Default: None.
-        channel_order (str): The channel order of image. Default: 'rgb'.
+            self.add(gt, pred, channel_order)
 
-    Returns:
-        float: SNR result.
-    """
+    def evaluate(self, *args, **kwargs):
+        """Returns metric results and print pretty table of metrics per class.
 
-    assert gt.shape == pred.shape, (
-        f'Image shapes are different: {gt.shape}, {pred.shape}.')
+        This method would be invoked by ``mmengine.Evaluator``.
+        """
+        metric_results = self.compute(*args, **kwargs)
+        self.reset()
 
-    gt = img_transform(
-        gt,
-        crop_border=crop_border,
-        input_order=input_order,
-        convert_to=convert_to,
-        channel_order=channel_order)
-    pred = img_transform(
-        pred,
-        crop_border=crop_border,
-        input_order=input_order,
-        convert_to=convert_to,
-        channel_order=channel_order)
-
-    signal = ((gt)**2).mean()
-    noise = ((gt - pred)**2).mean()
-
-    result = 10. * np.log10(signal / noise)
-
-    return result
+        key_template = f'{self.prefix}/{{}}' if self.prefix else '{}'
+        return {
+            key_template.format(k): v * self.scaling
+            for k, v in metric_results.items()
+        }


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Support MMEval's SSIM and SNR metric in MMEditing-1.x.

## Comparsion with Default Implementation

* Config: `esrgan_psnr-x4c64b23g32_1xb16-1000k_div2k.py`
* Pretrain Model: [url](https://download.openmmlab.com/mmediting/restorers/esrgan/esrgan_x4c64b23g32_1x16_400k_div2k_20200508-f8ccaf3b.pth)
* Slightly modification of the config: Change `PSNR` metric to `SNR` metric to comparison the performance.
* Known difference between MMEval and MMEditing: MMEval use `np.float64` to calculate SNR metric, and MMEditing use `np.float32`.
* Unit test for MMEditing has not be revised.

### Single GPU

* MMEditing-1.x (9min 42s)
![single-mmediting](https://user-images.githubusercontent.com/28132635/196877286-e8db2e8e-0dff-40d7-abd4-c98a8fe3266a.png)

* MMEditing with MMEval (9min 50s)
![single-mmeval](https://user-images.githubusercontent.com/28132635/196882100-1913d9d5-6219-4c20-a04c-35c3f3f7d369.png)

### Multi GPUs (2 GPUs)

* MMEditing-1.x (4min 52s)
![multi-mmediting](https://user-images.githubusercontent.com/28132635/196877302-5da0495d-0ac2-4d55-853e-524e0926f8d4.png)

* MMEditing with MMEval (4min 52s)
![multi-mmeval](https://user-images.githubusercontent.com/28132635/196877511-3e243bae-7cb1-46ea-b4d6-9b0a40a41ed2.png)

## Who can help? @ them here!

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

**Before PR**:

- [x] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmediting/blob/master/.github/CONTRIBUTING.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmediting/blob/master/.github/CONTRIBUTING.md) are used to fix the potential lint issues.
- [x] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [x] If the modification has potential influence on downstream or other related projects, this PR should be tested with some of those projects.
- [x] CLA has been signed and all committers have signed the CLA in this PR.
