### PR TITLE
Feature] Adopt mmeval's PSNR, MAE and MSE in mmediting

### DIFF
--- a/mmedit/evaluation/metrics/__init__.py
+++ b/mmedit/evaluation/metrics/__init__.py
@@ -12,7 +12,7 @@ from .mse import MSE
 from .niqe import NIQE, niqe
 from .ppl import PerceptualPathLength
 from .precision_and_recall import PrecisionAndRecall
-from .psnr import PSNR, psnr
+from .psnr import PSNR
 from .sad import SAD
 from .snr import SNR, snr
 from .ssim import SSIM, ssim
@@ -22,7 +22,6 @@ __all__ = [
     'MAE',
     'MSE',
     'PSNR',
-    'psnr',
     'SNR',
     'snr',
     'SSIM',

--- a/mmedit/evaluation/metrics/mae.py
+++ b/mmedit/evaluation/metrics/mae.py
@@ -1,31 +1,33 @@
 # Copyright (c) OpenMMLab. All rights reserved.
-"""Evaluation metrics based on pixels."""
+from typing import Optional, Sequence
 
-import numpy as np
+from mmeval import MAE as MAE_MMEVAL
 
 from mmedit.registry import METRICS
-from .base_sample_wise_metric import BaseSampleWiseMetric
+from .metrics_utils import obtain_data
 
 
 @METRICS.register_module()
-class MAE(BaseSampleWiseMetric):
+class MAE(MAE_MMEVAL):
     """Mean Absolute Error metric for image.
 
     mean(abs(a-b))
 
     Args:
-
         gt_key (str): Key of ground-truth. Default: 'gt_img'
         pred_key (str): Key of prediction. Default: 'pred_img'
         mask_key (str, optional): Key of mask, if mask_key is None, calculate
             all regions. Default: None
-        collect_device (str): Device name used for collecting results from
-            different ranks during distributed training. Must be 'cpu' or
-            'gpu'. Defaults to 'cpu'.
+        scaling (float, optional): Scaling factor for final metric.
+            E.g. scaling=100 means the final metric will be amplified by 100
+            for output. Default: 1
         prefix (str, optional): The prefix that will be added in the metric
             names to disambiguate homonymous metrics of different evaluators.
             If prefix is not provided in the argument, self.default_prefix
-            will be used instead. Default: None
+            will be used instead. Default: None.
+        dist_backend (str | None): The name of the distributed communication
+            backend. Refer to :class:`mmeval.BaseMetric`.
+            Defaults to 'torch_cuda'.
 
     Metrics:
         - MAE (float): Mean of Absolute Error
@@ -33,28 +35,59 @@ class MAE(BaseSampleWiseMetric):
 
     metric = 'MAE'
 
-    def process_image(self, gt, pred, mask):
-        """Process an image.
+    def __init__(self,
+                 gt_key: str = 'gt_img',
+                 pred_key: str = 'pred_img',
+                 mask_key: Optional[str] = None,
+                 scaling: float = 1,
+                 prefix: Optional[str] = None,
+                 dist_backend: str = 'torch_cuda',
+                 **kwargs) -> None:
+        super().__init__(dist_backend=dist_backend, **kwargs)
+
+        self.gt_key = gt_key
+        self.pred_key = pred_key
+        self.mask_key = mask_key
+        self.scaling = scaling
+        self.prefix = prefix
+
+    def process(self, data_batch: Sequence[dict],
+                data_samples: Sequence[dict]) -> None:
+        """Process one batch of data and predictions.
 
         Args:
-            gt (Tensor | np.ndarray): GT image.
-            pred (Tensor | np.ndarray): Pred image.
-            mask (Tensor | np.ndarray): Mask of evaluation.
-        Returns:
-            result (np.ndarray): MAE result.
+            data_batch (Sequence[dict]): A batch of data
+                from the dataloader.
+            predictions (Sequence[dict]): A batch of outputs from
+                the model.
         """
 
-        gt = gt / 255.
-        pred = pred / 255.
+        for data in data_samples:
+            prediction = data['output']
 
-        diff = gt - pred
-        diff = abs(diff)
+            # convert to list of np.ndarray
+            gt = [obtain_data(data, self.gt_key).numpy()]
+            pred = [obtain_data(prediction, self.pred_key).numpy()]
+            if self.mask_key is not None:
+                mask = obtain_data(data, self.gt_key).numpy()
+                mask[mask != 0] = 1
+                mask = [mask]
+            else:
+                mask = [1 - p * 0 for p in pred]
 
-        if self.mask_key is not None:
-            diff *= mask  # broadcast for channel dimension
-            scale = np.prod(diff.shape) / np.prod(mask.shape)
-            result = diff.sum() / (mask.sum() * scale + 1e-12)
-        else:
-            result = diff.mean()
+            self.add(pred, gt, mask)
 
-        return result
+    def evaluate(self, *args, **kwargs):
+        """Returns metric results and print pretty table of metrics per class.
+
+        This method would be invoked by ``mmengine.Evaluator``.
+        """
+
+        metric_results = self.compute(*args, **kwargs)
+        self.reset()
+
+        key_template = f'{self.prefix}/{{}}' if self.prefix else '{}'
+        return {
+            key_template.format(k): v * self.scaling
+            for k, v in metric_results.items()
+        }

--- a/mmedit/evaluation/metrics/ssim.py
+++ b/mmedit/evaluation/metrics/ssim.py
@@ -158,8 +158,7 @@ def ssim(img1,
 
     assert img1.shape == img2.shape, (
         f'Image shapes are different: {img1.shape}, {img2.shape}.')
-    # import torch
-    # img2 = torch.round(img2)
+
     img1 = img_transform(
         img1,
         crop_border=crop_border,

--- a/mmedit/evaluation/metrics/ssim.py
+++ b/mmedit/evaluation/metrics/ssim.py
@@ -158,7 +158,8 @@ def ssim(img1,
 
     assert img1.shape == img2.shape, (
         f'Image shapes are different: {img1.shape}, {img2.shape}.')
-
+    # import torch
+    # img2 = torch.round(img2)
     img1 = img_transform(
         img1,
         crop_border=crop_border,


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Support MMEval's PSNR, MAE and MSE metric in MMEditing-1.x.

## Comparsion with Default Implementation

* Config: `configs/edvr/edvrm_8xb4-600k_reds.py`
* Pretrain Model: [url](https://download.openmmlab.com/mmediting/restorers/edvr/edvrm_x4_8x4_600k_reds_20210625-e29b71b5.pth)
* Slightly modification of the config: Add `MAE` metric to `MSE` metric to comparison the performance.
* Known difference between MMEval and MMEditing: MMEval use `np.float64` to calculate PSNR metric, and MMEditing use `np.float32`.
* Unit test for MMEditing has not be revised.

* MMEditing-1.x (1min 51s)
![single-mmediting](https://user-images.githubusercontent.com/49083766/196923399-fa3d7640-9055-42a0-a920-9c6e929ac27f.png)

* MMEditing with MMEval (2min 35s)
![single-mmeval](https://user-images.githubusercontent.com/49083766/196923301-004b0a7a-013d-488e-870d-82b6dbd2f6bc.png)


## Who can help? @ them here!

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

**Before PR**:

- [x] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmediting/blob/master/.github/CONTRIBUTING.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmediting/blob/master/.github/CONTRIBUTING.md) are used to fix the potential lint issues.
- [x] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [x] If the modification has potential influence on downstream or other related projects, this PR should be tested with some of those projects.
- [x] CLA has been signed and all committers have signed the CLA in this PR.
