### PR TITLE
[Config] Revise discriminator's learning rate of TTSR to align with 0.x version

### DIFF
--- a/configs/ttsr/ttsr-gan_x4c64b16_1xb9-500k_CUFED.py
+++ b/configs/ttsr/ttsr-gan_x4c64b16_1xb9-500k_CUFED.py
@@ -61,7 +61,7 @@ optim_wrapper = dict(
         optimizer=dict(type='Adam', lr=1e-5, betas=(0.9, 0.999))),
     discriminator=dict(
         type='OptimWrapper',
-        optimizer=dict(type='Adam', lr=1e-4, betas=(0.9, 0.999))))
+        optimizer=dict(type='Adam', lr=1e-5, betas=(0.9, 0.999))))
 
 # learning policy
 param_scheduler = dict(


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

The discriminator's learning rate of TTSR model is misaligned with 1.x and 0.x (1e-4 and 1e-5 respectively).

## Modification

Change lr to `1e-5`.

## Who can help? @ them here!

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

**Before PR**:

- [x] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmediting/blob/master/.github/CONTRIBUTING.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmediting/blob/master/.github/CONTRIBUTING.md) are used to fix the potential lint issues.
- [x] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [x] If the modification has potential influence on downstream or other related projects, this PR should be tested with some of those projects.
- [x] CLA has been signed and all committers have signed the CLA in this PR.
