### PR TITLE
[Enhancement] Support deterministic training in benchmark

### DIFF
--- a/.dev_scripts/README.md
+++ b/.dev_scripts/README.md
@@ -211,7 +211,15 @@ python .dev_scripts/train_benchmark.py mm_lol \
 
 Specifically, `--rerun-fail` and `--rerun-cancel` can be used together to rerun both failed and cancaled jobs.
 
-## 8. Automatically check links
+## 8. `deterministic` training
+
+Set `torch.backends.cudnn.deterministic = True` and `torch.backends.cudnn.benchmark = False` can remove randomness operation in Pytorch training. You can add `--deterministic` flag when start your benchmark training to remove the influence of randomness operation.
+
+```shell
+python .dev_scripts/train_benchmark.py mm_lol --job-name xzn --models pix2pix --cpus-per-job 16 --run --deterministic
+```
+
+## 9. Automatically check links
 
 Use the following script to check whether the links in documentations are valid:
 

--- a/.dev_scripts/train_benchmark.py
+++ b/.dev_scripts/train_benchmark.py
@@ -243,7 +243,8 @@ def create_train_job_batch(commands, model_info, args, port, script_name):
         job_script += (f'#SBATCH --gres=gpu:{n_gpus}\n'
                        f'#SBATCH --ntasks-per-node={min(n_gpus, 8)}\n'
                        f'#SBATCH --ntasks={n_gpus}\n'
-                       f'#SBATCH --cpus-per-task={args.cpus_per_job}\n\n')
+                       f'#SBATCH --cpus-per-task={args.cpus_per_job}\n'
+                       f'#SBATCH --kill-on-bad-exit=1\n\n')
     else:
         job_script += '\n\n' + 'export CUDA_VISIBLE_DEVICES=-1\n'
 

--- a/.dev_scripts/train_benchmark.py
+++ b/.dev_scripts/train_benchmark.py
@@ -118,6 +118,10 @@ def parse_args():
         default='work_dirs/benchmark_train',
         help='the dir to save metric')
     parser.add_argument(
+        '--deterministic',
+        action='store_true',
+        help='Whether set `deterministic` during training.')
+    parser.add_argument(
         '--run', action='store_true', help='run script directly')
     parser.add_argument(
         '--local',
@@ -243,6 +247,9 @@ def create_train_job_batch(commands, model_info, args, port, script_name):
     else:
         job_script += '\n\n' + 'export CUDA_VISIBLE_DEVICES=-1\n'
 
+    if args.deterministic:
+        job_script += 'export CUBLAS_WORKSPACE_CONFIG=:4096:8\n'
+
     job_script += (f'export MASTER_PORT={port}\n'
                    f'{runner} -u {script_name} {config} '
                    f'--work-dir={work_dir} '
@@ -253,6 +260,9 @@ def create_train_job_batch(commands, model_info, args, port, script_name):
 
     if args.amp:
         job_script += ' --amp  '
+
+    if args.deterministic:
+        job_script += ' --cfg-options randomness.deterministic=True'
 
     job_script += '\n'
 


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Support deterministic training in training benchmark. Please refers to [readme](https://github.com/LeoXing1996/mmediting/blob/5610fdcbbe66f56741e48572a3049f7ac5080d10/.dev_scripts/README.md).

## Modification

Support `--deterministic` flag in `train_benchmark.py`. If `--deterministic` is set, `randomness` fields in config will be modified by `--cfg-options=randomness.determinstic=True`. Environment variable `CUBLAS_WORKSPACE_CONFIG=:4096:8` will be added to the job script as well. 

## Who can help? @ them here!

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

**Before PR**:

- [x] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmediting/blob/master/.github/CONTRIBUTING.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmediting/blob/master/.github/CONTRIBUTING.md) are used to fix the potential lint issues.
- [x] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [x] If the modification has potential influence on downstream or other related projects, this PR should be tested with some of those projects.
- [x] CLA has been signed and all committers have signed the CLA in this PR.
