### PR TITLE
[Enhancement] Support `try_import` for `mmdet`

### DIFF
--- a/mmedit/datasets/transforms/crop.py
+++ b/mmedit/datasets/transforms/crop.py
@@ -15,9 +15,7 @@ from torch.nn.modules.utils import _pair
 from mmedit.registry import TRANSFORMS
 from mmedit.utils import get_box_info, random_choose_unknown, try_import
 
-# from mmdet.apis import inference_detector, init_detector
-
-mmdet = try_import('mmdet')
+mmdet_apis = try_import('mmdet.apis')
 
 
 @TRANSFORMS.register_module()
@@ -946,13 +944,13 @@ class InstanceCrop(BaseTransform):
                  box_num_upbound=-1,
                  finesize=256):
 
-        assert mmdet is not None, (
+        assert mmdet_apis is not None, (
             "Cannot import 'mmdet'. Please install 'mmdet' via "
             "\"mim install 'mmdet >= 3.0.0rc2'\".")
 
         cfg = get_config(config_file, pretrained=True)
         with DefaultScope.overwrite_default_scope('mmdet'):
-            self.predictor = mmdet.api.init_detector(cfg, cfg.model_path)
+            self.predictor = mmdet_apis.init_detector(cfg, cfg.model_path)
 
         self.key = key
         self.box_num_upbound = box_num_upbound
@@ -1025,7 +1023,8 @@ class InstanceCrop(BaseTransform):
 
         with DefaultScope.overwrite_default_scope('mmdet'):
             with torch.no_grad():
-                results = mmdet.api.inference_detector(self.predictor, l_stack)
+                results = mmdet_apis.inference_detector(
+                    self.predictor, l_stack)
 
         bboxes = results.pred_instances.bboxes.cpu().numpy().astype(np.int32)
         scores = results.pred_instances.scores.cpu().numpy()

--- a/mmedit/utils/__init__.py
+++ b/mmedit/utils/__init__.py
@@ -5,14 +5,14 @@ from .io_utils import MMEDIT_CACHE_DIR, download_from_url
 # TODO replace with engine's API
 from .logger import print_colored_log
 from .sampler import get_sampler
-from .setup_env import register_all_modules
+from .setup_env import register_all_modules, try_import
 from .trans_utils import (add_gaussian_noise, adjust_gamma, bbox2mask,
                           brush_stroke_mask, get_irregular_mask, make_coord,
                           random_bbox, random_choose_unknown)
 from .typing import ForwardInputs, LabelVar, NoiseVar, SampleList
 
 __all__ = [
-    'modify_args', 'print_colored_log', 'register_all_modules',
+    'modify_args', 'print_colored_log', 'register_all_modules', 'try_import',
     'ForwardInputs', 'SampleList', 'NoiseVar', 'LabelVar', 'MMEDIT_CACHE_DIR',
     'download_from_url', 'get_sampler', 'tensor2img', 'random_choose_unknown',
     'add_gaussian_noise', 'adjust_gamma', 'make_coord', 'bbox2mask',

--- a/mmedit/utils/setup_env.py
+++ b/mmedit/utils/setup_env.py
@@ -1,6 +1,9 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 import datetime
+import importlib
 import warnings
+from types import ModuleType
+from typing import Optional
 
 from mmengine import DefaultScope
 
@@ -39,3 +42,19 @@ def register_all_modules(init_default_scope: bool = True) -> None:
             # avoid name conflict
             new_instance_name = f'mmedit-{datetime.datetime.now()}'
             DefaultScope.get_instance(new_instance_name, scope_name='mmedit')
+
+
+def try_import(name: str) -> Optional[ModuleType]:
+    """Try to import a module.
+
+    Args:
+        name (str): Specifies what module to import in absolute or relative
+            terms (e.g. either pkg.mod or ..mod).
+    Returns:
+        ModuleType or None: If importing successfully, returns the imported
+        module, otherwise returns None.
+    """
+    try:
+        return importlib.import_module(name)
+    except ImportError:
+        return None

--- a/tests/test_utils/test_setup_env.py
+++ b/tests/test_utils/test_setup_env.py
@@ -1,6 +1,12 @@
 # Copyright (c) OpenMMLab. All rights reserved.
-from mmedit.utils import register_all_modules
+from mmedit.utils import register_all_modules, try_import
 
 
 def test_register_all_modules():
     register_all_modules()
+
+
+def test_try_import():
+    import numpy as np
+    assert try_import('numpy') is np
+    assert try_import('numpy111') is None


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

In `crop.py`, mmdet, which is a optional installed package, is imported at the start of the file. This is very unfriendly for users.

## Modification

Support `try_import` and use `try_import` to import `mmdet`.

## Who can help? @ them here!

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

**Before PR**:

- [x] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmediting/blob/master/.github/CONTRIBUTING.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmediting/blob/master/.github/CONTRIBUTING.md) are used to fix the potential lint issues.
- [x] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [x] If the modification has potential influence on downstream or other related projects, this PR should be tested with some of those projects.
- [x] CLA has been signed and all committers have signed the CLA in this PR.
