### PR TITLE
[Enhancement] Support conditional input for StyleGAN modules

### DIFF
--- a/mmedit/models/base_models/base_conditional_gan.py
+++ b/mmedit/models/base_models/base_conditional_gan.py
@@ -85,14 +85,14 @@ class BaseConditionalGAN(BaseGAN):
             num_classes=self.num_classes,
             device=self.device)
 
-    def data_sample_to_label(self,
-                             data_sample: list) -> Optional[torch.Tensor]:
+    def data_sample_to_label(self, data_sample: List[EditDataSample]
+                             ) -> Optional[torch.Tensor]:
         """Get labels from input `data_sample` and pack to `torch.Tensor`. If
         no label is found in the passed `data_sample`, `None` would be
         returned.
 
         Args:
-            data_sample (List[InstanceData]): Input data samples.
+            data_sample (List[EditDataSample]): Input data samples.
 
         Returns:
             Optional[torch.Tensor]: Packed label tensor.

--- a/mmedit/models/editors/stylegan2/stylegan2_discriminator.py
+++ b/mmedit/models/editors/stylegan2/stylegan2_discriminator.py
@@ -58,6 +58,12 @@ class StyleGAN2Discriminator(BaseModule):
     Args:
         in_size (int): The input size of images.
         img_channels (int): The number of channels of the input image. Defaults to 3.
+        channel_multiplier (int, optional): The multiplier factor for the
+            channel number. Defaults to 2.
+        blur_kernel (list, optional): The blurry kernel. Defaults
+            to [1, 3, 3, 1].
+        mbstd_cfg (dict, optional): Configs for minibatch-stddev layer.
+            Defaults to dict(group_size=4, channel_groups=1).
         c_dim (int, optional): The dimension of conditional input. If None or
             less than 1, no conditional mapping will be applied. Defaults to None.
         cmap_dim (int, optional): The dimension of the output of conditional
@@ -67,12 +73,6 @@ class StyleGAN2Discriminator(BaseModule):
             input. Only work when c_dim is larger than 0. If :attr:`cmapping_layer`
             is None and :attr:`c_dim` is larger than 0, cmapping_layer will set as 8.
             Defaults to None.
-        channel_multiplier (int, optional): The multiplier factor for the
-            channel number. Defaults to 2.
-        blur_kernel (list, optional): The blurry kernel. Defaults
-            to [1, 3, 3, 1].
-        mbstd_cfg (dict, optional): Configs for minibatch-stddev layer.
-            Defaults to dict(group_size=4, channel_groups=1).
         num_fp16_scales (int, optional): The number of resolutions to use auto
             fp16 training. Defaults to 0.
         fp16_enabled (bool, optional): Whether to use fp16 training in this

--- a/mmedit/models/editors/stylegan2/stylegan2_generator.py
+++ b/mmedit/models/editors/stylegan2/stylegan2_generator.py
@@ -440,7 +440,7 @@ class StyleGAN2Generator(nn.Module):
         # update w_avg during training, if need
         if hasattr(self, 'w_avg') and self.training:
             # only update w_avg with the first style code
-            self.w_avg.copy_(styles_list[0].detach().mean(
+            self.w_avg.copy_(styles[0].detach().mean(
                 dim=0).lerp(self.w_avg, self.w_avg_beta))
 
         if injected_noise is None:

--- a/mmedit/models/editors/stylegan2/stylegan2_generator.py
+++ b/mmedit/models/editors/stylegan2/stylegan2_generator.py
@@ -56,9 +56,9 @@ class StyleGAN2Generator(nn.Module):
     Args:
         out_size (int): The output size of the StyleGAN2 generator.
         style_channels (int): The number of channels for style code.
-        noise_channels (int, optional): The number of channels for input noise.
-            If not passed, will be set the same value as :attr:`style_channels`.
-            Defaults to None.
+        noise_noise (int, optional): The size of (number of channels) the input
+            noise. If not passed, will be set the same value as
+            :attr:`style_channels`. Defaults to None.
         num_mlps (int, optional): The number of MLP layers. Defaults to 8.
         channel_multiplier (int, optional): The multiplier factor for the
             channel number. Defaults to 2.
@@ -350,6 +350,7 @@ class StyleGAN2Generator(nn.Module):
             injected_noise (torch.Tensor | None, optional): Given a tensor, the
                 random noise will be fixed as this input injected noise.
                 Defaults to None.
+            add_noise (bool): Whether apply noise injection. Defaults to True.
             randomize_noise (bool, optional): If `False`, images are sampled
                 with the buffered noise tensor injected to the style conv
                 block. Defaults to True.
@@ -394,7 +395,7 @@ class StyleGAN2Generator(nn.Module):
 
         # no amp for style-mapping and condition-embedding
         if not input_is_latent:
-            noise_batch = [s.clone() for s in styles]
+            noise_batch = styles
             # NOTE: do pixel_norm (2nd_momuent_norm) to noise input
             styles = [self.pixel_norm(s) for s in styles]
             if self.cond_channels is not None and self.cond_channels > 0:

--- a/mmedit/models/editors/stylegan2/stylegan2_generator.py
+++ b/mmedit/models/editors/stylegan2/stylegan2_generator.py
@@ -196,7 +196,7 @@ class StyleGAN2Generator(nn.Module):
         self.upsamples = nn.ModuleList()
         self.to_rgbs = nn.ModuleList()
 
-        blk_in_channels_ = self.channels[4]
+        blk_in_channels_ = self.channels[4]  # in channels of the conv blocks
 
         for i in range(3, self.log_size + 1):
             blk_out_channels_ = self.channels[2**i]

--- a/mmedit/models/editors/stylegan2/stylegan2_generator.py
+++ b/mmedit/models/editors/stylegan2/stylegan2_generator.py
@@ -315,6 +315,7 @@ class StyleGAN2Generator(nn.Module):
                 truncation_latent=None,
                 input_is_latent=False,
                 injected_noise=None,
+                add_noise=True,
                 randomize_noise=True):
         """Forward function.
 
@@ -464,7 +465,11 @@ class StyleGAN2Generator(nn.Module):
             out = self.constant_input(latent)
             if self.fp16_enabled:
                 out = out.to(torch.float16)
-            out = self.conv1(out, latent[:, 0], noise=injected_noise[0])
+            out = self.conv1(
+                out,
+                latent[:, 0],
+                noise=injected_noise[0],
+                add_noise=add_noise)
             skip = self.to_rgb1(out, latent[:, 1])
 
             _index = 1
@@ -473,8 +478,13 @@ class StyleGAN2Generator(nn.Module):
             for up_conv, conv, noise1, noise2, to_rgb in zip(
                     self.convs[::2], self.convs[1::2], injected_noise[1::2],
                     injected_noise[2::2], self.to_rgbs):
-                out = up_conv(out, latent[:, _index], noise=noise1)
-                out = conv(out, latent[:, _index + 1], noise=noise2)
+                out = up_conv(
+                    out, latent[:, _index], noise=noise1, add_noise=add_noise)
+                out = conv(
+                    out,
+                    latent[:, _index + 1],
+                    noise=noise2,
+                    add_noise=add_noise)
                 skip = to_rgb(out, latent[:, _index + 2], skip)
                 _index += 2
 

--- a/mmedit/models/editors/stylegan2/stylegan2_generator.py
+++ b/mmedit/models/editors/stylegan2/stylegan2_generator.py
@@ -257,6 +257,7 @@ class StyleGAN2Generator(nn.Module):
             # assign avg style code here and update with EMA.
             self.register_buffer('w_avg', torch.zeros([style_channels]))
             self.w_avg_beta = w_avg_beta
+            mmengine.print_log('Mean latent code (w) is updated with EMA.')
 
         if pretrained is not None:
             self._load_pretrained_model(**pretrained)
@@ -313,6 +314,7 @@ class StyleGAN2Generator(nn.Module):
             Tensor: Mean latent of this generator.
         """
         if hasattr(self, 'w_avg'):
+            mmengine.print_log('Get latent code (w) which is updated by EMA.')
             return self.w_avg
         return get_mean_latent(self, num_samples, **kwargs)
 

--- a/mmedit/models/editors/stylegan2/stylegan2_generator.py
+++ b/mmedit/models/editors/stylegan2/stylegan2_generator.py
@@ -118,7 +118,6 @@ class StyleGAN2Generator(nn.Module):
         self.default_style_mode = default_style_mode
         self.eval_style_mode = eval_style_mode
         self.mix_prob = mix_prob
-        # self.norm_input = norm_input
         self.num_fp16_scales = num_fp16_scales
         self.fp16_enabled = fp16_enabled
         self.bgr2rgb = bgr2rgb

--- a/mmedit/models/editors/stylegan2/stylegan2_generator.py
+++ b/mmedit/models/editors/stylegan2/stylegan2_generator.py
@@ -337,7 +337,8 @@ class StyleGAN2Generator(nn.Module):
                 input_is_latent=False,
                 injected_noise=None,
                 add_noise=True,
-                randomize_noise=True):
+                randomize_noise=True,
+                update_ws=False):
         """Forward function.
 
         This function has been integrated with the truncation trick. Please
@@ -375,6 +376,8 @@ class StyleGAN2Generator(nn.Module):
             randomize_noise (bool, optional): If `False`, images are sampled
                 with the buffered noise tensor injected to the style conv
                 block. Defaults to True.
+            update_ws (bool): Whether update latent code with EMA. Only work
+                when `w_avg` is registeried. Defaults to False.
 
         Returns:
             torch.Tensor | dict: Generated image tensor or dictionary \
@@ -438,7 +441,7 @@ class StyleGAN2Generator(nn.Module):
             noise_batch = None
 
         # update w_avg during training, if need
-        if hasattr(self, 'w_avg') and self.training:
+        if hasattr(self, 'w_avg') and self.training and update_ws:
             # only update w_avg with the first style code
             self.w_avg.copy_(styles[0].detach().mean(
                 dim=0).lerp(self.w_avg, self.w_avg_beta))

--- a/mmedit/models/editors/stylegan3/stylegan3_modules.py
+++ b/mmedit/models/editors/stylegan3/stylegan3_modules.py
@@ -207,6 +207,9 @@ class MappingNetwork(nn.Module):
         x = None
         # Embed, normalize, and concatenate inputs.
         if self.noise_size > 0:
+            assert z is not None, (
+                '\'z\' must be passed since \'self.noise_size\''
+                f'({self.noise_size}) larger than 0.')
             x = z.to(torch.float32)
             x = x * (x.square().mean(1, keepdim=True) + 1e-8).rsqrt()
         if self.cond_size > 0:

--- a/mmedit/models/editors/stylegan3/stylegan3_modules.py
+++ b/mmedit/models/editors/stylegan3/stylegan3_modules.py
@@ -175,7 +175,7 @@ class MappingNetwork(nn.Module):
                 activation='lrelu',
                 lr_multiplier=lr_multiplier)
             setattr(self, f'fc{idx}', layer)
-        if num_ws is not None and w_avg_beta is not None:
+        if w_avg_beta is not None:
             self.register_buffer('w_avg', torch.zeros([style_channels]))
 
     def forward(self,
@@ -227,8 +227,6 @@ class MappingNetwork(nn.Module):
         if self.num_ws is not None:
             x = x.unsqueeze(1).repeat([1, self.num_ws, 1])
         if truncation != 1:
-            assert hasattr(self, 'w_avg'), (
-                '\'w_avg\' must not be None when truncation trick is used.')
             if num_truncation_layer is None:
                 x = self.w_avg.lerp(x, truncation)
             else:

--- a/mmedit/models/editors/stylegan3/stylegan3_modules.py
+++ b/mmedit/models/editors/stylegan3/stylegan3_modules.py
@@ -227,6 +227,8 @@ class MappingNetwork(nn.Module):
         if self.num_ws is not None:
             x = x.unsqueeze(1).repeat([1, self.num_ws, 1])
         if truncation != 1:
+            assert hasattr(self, 'w_avg'), (
+                '\'w_avg\' must not be None when truncation trick is used.')
             if num_truncation_layer is None:
                 x = self.w_avg.lerp(x, truncation)
             else:

--- a/mmedit/models/editors/stylegan3/stylegan3_modules.py
+++ b/mmedit/models/editors/stylegan3/stylegan3_modules.py
@@ -128,7 +128,8 @@ class MappingNetwork(nn.Module):
 
     Args:
         noise_size (int, optional): Size of the input noise vector.
-        c_dim (int, optional): Size of the input noise vector.
+        cond_channels(int, optional): Size of the conditional vector.
+            Defaults to None.
         style_channels (int): The number of channels for style code.
         num_ws (int): The repeat times of w latent.
         num_layers (int, optional): The number of layers of mapping network.
@@ -143,23 +144,26 @@ class MappingNetwork(nn.Module):
                  noise_size,
                  style_channels,
                  num_ws,
-                 c_dim=0,
+                 cond_channels=0,
                  num_layers=2,
                  lr_multiplier=0.01,
                  w_avg_beta=0.998):
         super().__init__()
         self.noise_size = noise_size
-        self.c_dim = c_dim
+        self.cond_channels = cond_channels
         self.style_channels = style_channels
         self.num_ws = num_ws
         self.num_layers = num_layers
         self.w_avg_beta = w_avg_beta
 
         # Construct layers.
-        self.embed = FullyConnectedLayer(
-            self.c_dim, self.style_channels) if self.c_dim > 0 else None
+        if self.cond_channels is not None and self.cond_channels > 0:
+            self.embed = FullyConnectedLayer(self.cond_channels,
+                                             self.style_channels)
+
         features = [
-            self.noise_size + (self.style_channels if self.c_dim > 0 else 0)
+            self.noise_size +
+            (self.style_channels if self.cond_channels > 0 else 0)
         ] + [self.style_channels] * self.num_layers
         for idx, in_features, out_features in zip(
                 range(num_layers), features[:-1], features[1:]):
@@ -174,7 +178,7 @@ class MappingNetwork(nn.Module):
 
     def forward(self,
                 z,
-                c=None,
+                cond=None,
                 truncation=1,
                 num_truncation_layer=None,
                 update_emas=False):
@@ -182,7 +186,8 @@ class MappingNetwork(nn.Module):
 
         Args:
             z (torch.Tensor): Input noise tensor.
-            c (torch.Tensor, optional): Input label tensor. Defaults to None.
+            cond (torch.Tensor, optional): Input label tensor.
+                Defaults to None.
             truncation (float, optional): Truncation factor. Give value less
                 than 1., the truncation trick will be adopted. Defaults to 1.
             num_truncation_layer (int, optional): Number of layers use
@@ -202,8 +207,8 @@ class MappingNetwork(nn.Module):
         if self.noise_size > 0:
             x = z.to(torch.float32)
             x = x * (x.square().mean(1, keepdim=True) + 1e-8).rsqrt()
-        if self.c_dim > 0:
-            y = self.embed(c.to(torch.float32))
+        if self.cond_channels > 0:
+            y = self.embed(cond.to(torch.float32))
             y = y * (y.square().mean(1, keepdim=True) + 1e-8).rsqrt()
             x = torch.cat([x, y], dim=1) if x is not None else y
 

--- a/mmedit/models/editors/stylegan3/stylegan3_modules.py
+++ b/mmedit/models/editors/stylegan3/stylegan3_modules.py
@@ -225,7 +225,9 @@ class MappingNetwork(nn.Module):
         if self.num_ws is not None:
             x = x.unsqueeze(1).repeat([1, self.num_ws, 1])
         if truncation != 1:
-            if self.num_ws is not None:
+            assert hasattr(self, 'w_avg'), (
+                '\'w_avg\' must not be None when truncation trick is used.')
+            if num_truncation_layer is None:
                 x = self.w_avg.lerp(x, truncation)
             else:
                 x[:, :num_truncation_layer] = self.w_avg.lerp(

--- a/mmedit/models/editors/stylegan3/stylegan3_modules.py
+++ b/mmedit/models/editors/stylegan3/stylegan3_modules.py
@@ -131,7 +131,9 @@ class MappingNetwork(nn.Module):
         cond_channels(int, optional): Size of the conditional vector.
             Defaults to None.
         style_channels (int): The number of channels for style code.
-        num_ws (int): The repeat times of w latent.
+        num_ws (int | None): The repeat times of w latent. If None is passed,
+            the output will shape like (batch_size, 1), otherwise the output
+            will shape like (bz, num_ws, 1).
         num_layers (int, optional): The number of layers of mapping network.
             Defaults to 2.
         lr_multiplier (float, optional): Equalized learning rate multiplier.

--- a/tests/test_models/test_editors/test_stylegan2/test_stylegan2_discriminator.py
+++ b/tests/test_models/test_editors/test_stylegan2/test_stylegan2_discriminator.py
@@ -31,11 +31,27 @@ class TestStyleGANv2Disc:
         score = d(img)
         assert score.shape == (2, 1)
 
+        cfg = deepcopy(self.default_cfg)
+        cfg['cond_channels'] = 5
+        cfg['cond_mapping_channels'] = 16
+
+        d = StyleGAN2Discriminator(**cfg)
+        score = d(img, torch.randn(2, 5))
+        assert score.shape == (2, 1)
+
     @pytest.mark.skipif(not torch.cuda.is_available(), reason='requires cuda')
     def test_stylegan2_disc_cuda(self):
         d = StyleGAN2Discriminator(**self.default_cfg).cuda()
         img = torch.randn((2, 3, 64, 64)).cuda()
         score = d(img)
+        assert score.shape == (2, 1)
+
+        cfg = deepcopy(self.default_cfg)
+        cfg['cond_channels'] = 5
+        cfg['cond_mapping_channels'] = 16
+
+        d = StyleGAN2Discriminator(**cfg)
+        score = d(img, torch.randn(2, 5).cuda())
         assert score.shape == (2, 1)
 
 

--- a/tests/test_models/test_editors/test_stylegan2/test_stylegan2_discriminator.py
+++ b/tests/test_models/test_editors/test_stylegan2/test_stylegan2_discriminator.py
@@ -32,7 +32,7 @@ class TestStyleGANv2Disc:
         assert score.shape == (2, 1)
 
         cfg = deepcopy(self.default_cfg)
-        cfg['cond_channels'] = 5
+        cfg['cond_size'] = 5
         cfg['cond_mapping_channels'] = 16
 
         d = StyleGAN2Discriminator(**cfg)
@@ -47,7 +47,7 @@ class TestStyleGANv2Disc:
         assert score.shape == (2, 1)
 
         cfg = deepcopy(self.default_cfg)
-        cfg['cond_channels'] = 5
+        cfg['cond_size'] = 5
         cfg['cond_mapping_channels'] = 16
 
         d = StyleGAN2Discriminator(**cfg).cuda()

--- a/tests/test_models/test_editors/test_stylegan2/test_stylegan2_discriminator.py
+++ b/tests/test_models/test_editors/test_stylegan2/test_stylegan2_discriminator.py
@@ -50,7 +50,7 @@ class TestStyleGANv2Disc:
         cfg['cond_channels'] = 5
         cfg['cond_mapping_channels'] = 16
 
-        d = StyleGAN2Discriminator(**cfg)
+        d = StyleGAN2Discriminator(**cfg).cuda()
         score = d(img, torch.randn(2, 5).cuda())
         assert score.shape == (2, 1)
 

--- a/tests/test_models/test_editors/test_stylegan2/test_stylegan2_generator.py
+++ b/tests/test_models/test_editors/test_stylegan2/test_stylegan2_generator.py
@@ -94,19 +94,19 @@ class TestStyleGAN2Generator:
 
         # test cond channels is negative number
         cfg_ = deepcopy(self.default_cfg)
-        cfg_['cond_channels'] = -1
+        cfg_['cond_size'] = -1
         g = StyleGAN2Generator(**cfg_)
         assert not hasattr(g, 'embed')
 
         # test cond channels > 0
         cfg_ = deepcopy(self.default_cfg)
-        cfg_['cond_channels'] = 10
+        cfg_['cond_size'] = 10
         g = StyleGAN2Generator(**cfg_)
         assert hasattr(g, 'embed')
         # test raise error
         with pytest.raises(AssertionError):
             g(None, num_batches=2)
-        res = g(None, num_batches=2, cond=torch.randn(2, 10))
+        res = g(None, num_batches=2, label=torch.randn(2, 10))
         assert res.shape == (2, 3, 64, 64)
 
     @pytest.mark.skipif(not torch.cuda.is_available(), reason='requires cuda')
@@ -165,17 +165,17 @@ class TestStyleGAN2Generator:
 
         # test cond channels is negative number
         cfg_ = deepcopy(self.default_cfg)
-        cfg_['cond_channels'] = -1
+        cfg_['cond_size'] = -1
         g = StyleGAN2Generator(**cfg_)
         assert not hasattr(g, 'embed')
 
         # test cond channels > 0
         cfg_ = deepcopy(self.default_cfg)
-        cfg_['cond_channels'] = 10
+        cfg_['cond_size'] = 10
         g = StyleGAN2Generator(**cfg_)
         assert hasattr(g, 'embed')
         # test raise error
         with pytest.raises(AssertionError):
             g(None, num_batches=2)
-        res = g(None, num_batches=2, cond=torch.randn(2, 10))
+        res = g(None, num_batches=2, label=torch.randn(2, 10))
         assert res.shape == (2, 3, 64, 64)

--- a/tests/test_models/test_editors/test_stylegan2/test_stylegan2_generator.py
+++ b/tests/test_models/test_editors/test_stylegan2/test_stylegan2_generator.py
@@ -24,6 +24,15 @@ class TestStyleGAN2Generator:
         res = g(None, num_batches=2)
         assert res.shape == (2, 3, 64, 64)
 
+        # test truncation_latent is None
+        assert not hasattr(g, 'truncation_latent')
+        res = g(None, num_batches=2, truncation=0.9)
+        assert res.shape == (2, 3, 64, 64)
+        assert hasattr(g, 'truncation_latent')
+        assert g.truncation_latent.shape == (1, 16)
+        res = g(None, num_batches=2, truncation=0.9)
+        assert res.shape == (2, 3, 64, 64)
+
         truncation_mean = g.get_mean_latent()
         res = g(
             None,

--- a/tests/test_models/test_editors/test_stylegan2/test_stylegan2_generator.py
+++ b/tests/test_models/test_editors/test_stylegan2/test_stylegan2_generator.py
@@ -123,17 +123,34 @@ class TestStyleGAN2Generator:
         # test update w_avg with ema
         g.eval()
         res = g(
-            None, num_batches=1, injected_noise=None, randomize_noise=False)
+            None,
+            num_batches=1,
+            injected_noise=None,
+            randomize_noise=False,
+            update_ws=True)
         mean_latent_test = g.get_mean_latent().clone()  # copy for test
         # should not be update in test
         assert (mean_latent_test == mean_latent).all()
 
         g.train()
         res = g(
-            None, num_batches=1, injected_noise=None, randomize_noise=False)
+            None,
+            num_batches=1,
+            injected_noise=None,
+            randomize_noise=False,
+            update_ws=True)
         mean_latent_train = g.get_mean_latent().clone()  # copy for test
         # should be update in train
         assert (mean_latent_train != mean_latent).any()
+
+        res = g(
+            None,
+            num_batches=1,
+            injected_noise=None,
+            randomize_noise=False,
+            update_ws=False)
+        mean_latent_no_update = g.get_mean_latent().clone()  # copy for test
+        assert (mean_latent_train == mean_latent_no_update).all()
 
     @pytest.mark.skipif(not torch.cuda.is_available(), reason='requires cuda')
     def test_g_cuda(self):

--- a/tests/test_models/test_editors/test_stylegan2/test_stylegan2_generator.py
+++ b/tests/test_models/test_editors/test_stylegan2/test_stylegan2_generator.py
@@ -98,7 +98,7 @@ class TestStyleGAN2Generator:
         with pytest.raises(AssertionError):
             g(None, num_batches=2)
         res = g(None, num_batches=2, cond=torch.randn(2, 10))
-        assert res.shape == (2, 3, 256, 256)
+        assert res.shape == (2, 3, 64, 64)
 
     @pytest.mark.skipif(not torch.cuda.is_available(), reason='requires cuda')
     def test_g_cuda(self):
@@ -169,4 +169,4 @@ class TestStyleGAN2Generator:
         with pytest.raises(AssertionError):
             g(None, num_batches=2)
         res = g(None, num_batches=2, cond=torch.randn(2, 10))
-        assert res.shape == (2, 3, 256, 256)
+        assert res.shape == (2, 3, 64, 64)

--- a/tests/test_models/test_editors/test_stylegan2/test_stylegan2_generator.py
+++ b/tests/test_models/test_editors/test_stylegan2/test_stylegan2_generator.py
@@ -83,6 +83,23 @@ class TestStyleGAN2Generator:
         g.mix_prob = 0
         res = g(None, num_batches=2)
 
+        # test cond channels is negative number
+        cfg_ = deepcopy(self.default_cfg)
+        cfg_['cond_channels'] = -1
+        g = StyleGAN2Generator(**cfg_)
+        assert not hasattr(g, 'embed')
+
+        # test cond channels > 0
+        cfg_ = deepcopy(self.default_cfg)
+        cfg_['cond_channels'] = 10
+        g = StyleGAN2Generator(**cfg_)
+        assert hasattr(g, 'embed')
+        # test raise error
+        with pytest.raises(AssertionError):
+            g(None, num_batches=2)
+        res = g(None, num_batches=2, cond=torch.randn(2, 10))
+        assert res.shape == (2, 3, 256, 256)
+
     @pytest.mark.skipif(not torch.cuda.is_available(), reason='requires cuda')
     def test_g_cuda(self):
         # test default config
@@ -136,3 +153,20 @@ class TestStyleGAN2Generator:
         res = g(None, num_batches=2)
         g.mix_prob = 0
         res = g(None, num_batches=2)
+
+        # test cond channels is negative number
+        cfg_ = deepcopy(self.default_cfg)
+        cfg_['cond_channels'] = -1
+        g = StyleGAN2Generator(**cfg_)
+        assert not hasattr(g, 'embed')
+
+        # test cond channels > 0
+        cfg_ = deepcopy(self.default_cfg)
+        cfg_['cond_channels'] = 10
+        g = StyleGAN2Generator(**cfg_)
+        assert hasattr(g, 'embed')
+        # test raise error
+        with pytest.raises(AssertionError):
+            g(None, num_batches=2)
+        res = g(None, num_batches=2, cond=torch.randn(2, 10))
+        assert res.shape == (2, 3, 256, 256)

--- a/tests/test_models/test_editors/test_stylegan2/test_stylegan2_modules.py
+++ b/tests/test_models/test_editors/test_stylegan2/test_stylegan2_modules.py
@@ -106,6 +106,21 @@ class TestModStyleConv:
         res = conv(input_x, input_style)
         assert res.shape == (2, 1, 4, 4)
 
+        # test add noise
+        noise = torch.randn(2, 1, 4, 4)
+        res = conv(input_x, input_style, noise)
+        assert res.shape == (2, 1, 4, 4)
+
+        # test add noise + return_noise
+        res = conv(input_x, input_style, noise, return_noise=True)
+        assert isinstance(res, tuple)
+        assert res[0].shape == (2, 1, 4, 4)
+        assert (res[1] == noise).all()
+
+        # test add noise is False
+        res = conv(input_x, input_style, noise, add_noise=False)
+        assert res.shape == (2, 1, 4, 4)
+
     @pytest.mark.skipif(not torch.cuda.is_available(), reason='requires cuda')
     def test_mod_styleconv_cuda(self):
         conv = ModulatedStyleConv(**self.default_cfg).cuda()
@@ -217,6 +232,17 @@ class TestToRGB:
         skip = torch.randn(2, 3, 4, 4)
         res = model(input_x, style, skip)
         assert res.shape == (2, 3, 8, 8)
+
+        # test skip is passed + upsample is False
+        cfg = deepcopy(self.default_cfg)
+        cfg['upsample'] = False
+        cfg['out_channels'] = 7
+        model = ModulatedToRGB(**cfg)
+        input_x = torch.randn((2, 5, 4, 4))
+        skip = torch.randn(2, 7, 4, 4)
+        style = torch.randn((2, 5))
+        res = model(input_x, style, skip)
+        assert res.shape == (2, 7, 4, 4)
 
     @pytest.mark.skipif(not torch.cuda.is_available(), reason='requires cuda')
     def test_torgb_cuda(self):

--- a/tests/test_models/test_editors/test_stylegan3/test_stylegan3_modules.py
+++ b/tests/test_models/test_editors/test_stylegan3/test_stylegan3_modules.py
@@ -5,8 +5,18 @@ from mmedit.models.editors.stylegan3.stylegan3_modules import MappingNetwork
 
 
 def test_MappingNetwork():
-    mapping_network = MappingNetwork(16, 4, 5, c_dim=8)
+    mapping_network = MappingNetwork(16, 4, 5, cond_channels=8)
     z = torch.randn(1, 16)
     c = torch.randn(1, 8)
     out = mapping_network(z, c)
+    assert out.shape == (1, 5, 4)
+
+    # test w/o conditional input
+    mapping_network = MappingNetwork(16, 4, 5, cond_channels=-1)
+    out = mapping_network(z)
+    assert out.shape == (1, 5, 4)
+
+    # test w/o noise input
+    mapping_network = MappingNetwork(0, 4, 5, cond_channels=8)
+    out = mapping_network(None, c)
     assert out.shape == (1, 5, 4)

--- a/tests/test_models/test_editors/test_stylegan3/test_stylegan3_modules.py
+++ b/tests/test_models/test_editors/test_stylegan3/test_stylegan3_modules.py
@@ -1,4 +1,5 @@
 # Copyright (c) OpenMMLab. All rights reserved.
+import pytest
 import torch
 
 from mmedit.models.editors.stylegan3.stylegan3_modules import MappingNetwork
@@ -20,3 +21,21 @@ def test_MappingNetwork():
     mapping_network = MappingNetwork(0, 4, 5, cond_channels=8)
     out = mapping_network(None, c)
     assert out.shape == (1, 5, 4)
+
+    # test num_ws is None --> no broadcast
+    mapping_network = MappingNetwork(16, 4, num_ws=None, w_avg_beta=None)
+    assert not hasattr(mapping_network, 'w_avg')
+    out = mapping_network(z)
+    assert out.shape == (1, 4)
+
+    # test truncation is passed
+    with pytest.raises(AssertionError):
+        mapping_network(z, truncation=0.9)
+
+    mapping_network = MappingNetwork(16, 4, 5)
+    out = mapping_network(z, truncation=0.9)
+    assert out.shape == (1, 5, 4)
+
+    out_trunc_work = mapping_network(z, truncation=0.9, num_truncation_layer=3)
+    assert out_trunc_work.shape == (1, 5, 4)
+    assert (out_trunc_work[3:] == out[3:]).all()

--- a/tests/test_models/test_editors/test_stylegan3/test_stylegan3_modules.py
+++ b/tests/test_models/test_editors/test_stylegan3/test_stylegan3_modules.py
@@ -6,19 +6,19 @@ from mmedit.models.editors.stylegan3.stylegan3_modules import MappingNetwork
 
 
 def test_MappingNetwork():
-    mapping_network = MappingNetwork(16, 4, 5, cond_channels=8)
+    mapping_network = MappingNetwork(16, 4, 5, cond_size=8)
     z = torch.randn(1, 16)
     c = torch.randn(1, 8)
     out = mapping_network(z, c)
     assert out.shape == (1, 5, 4)
 
     # test w/o conditional input
-    mapping_network = MappingNetwork(16, 4, 5, cond_channels=-1)
+    mapping_network = MappingNetwork(16, 4, 5, cond_size=-1)
     out = mapping_network(z)
     assert out.shape == (1, 5, 4)
 
     # test w/o noise input
-    mapping_network = MappingNetwork(0, 4, 5, cond_channels=8)
+    mapping_network = MappingNetwork(0, 4, 5, cond_size=8)
     out = mapping_network(None, c)
     assert out.shape == (1, 5, 4)
 

--- a/tests/test_models/test_editors/test_stylegan3/test_stylegan3_modules.py
+++ b/tests/test_models/test_editors/test_stylegan3/test_stylegan3_modules.py
@@ -39,3 +39,7 @@ def test_MappingNetwork():
     out_trunc_work = mapping_network(z, truncation=0.9, num_truncation_layer=3)
     assert out_trunc_work.shape == (1, 5, 4)
     assert (out_trunc_work[3:] == out[3:]).all()
+
+    # test z is None + noise_size > 0
+    with pytest.raises(AssertionError):
+        mapping_network(None)


### PR DESCRIPTION
## Motivation

1. EG3D use camera poses as conditional input in a slightly modified StyleGANv2 discriminator. This algorithm adds a mapping network before Discriminator as embedding layer.
2. StyleGAN's official repo support conditional input in discriminator.

## Modification

1. Add `MappingNetwork` in `StyleGAN2Discriminator`
2. Support no noise input (`x is None`) in `MappingNetwork`
3. Support conditional input in `StyleGAN2Generator`
4. Support no noise injection in `ModulatedStyleConv`
5. Support `skip` input + w/o upsample in `ModulatedToRGB`
6. Support update latent mean (`w_avg`) by EMA

## Whose help do you want? @ them here!

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

**Before PR**:

- [x] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmediting/blob/master/.github/CONTRIBUTING.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmediting/blob/master/.github/CONTRIBUTING.md) are used to fix the potential lint issues.
- [x] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [x] If the modification has potential influence on downstream or other related projects, this PR should be tested with some of those projects.
- [x] CLA has been signed and all committers have signed the CLA in this PR.
