### PR TITLE
[Fix] Wrong path resulsting in pre-commit error in Python 3.9

### DIFF
--- a/.dev_scripts/update_model_index.py
+++ b/.dev_scripts/update_model_index.py
@@ -16,7 +16,7 @@ from functools import reduce
 
 import mmengine
 
-MMEditing_ROOT = osp.dirname(osp.dirname(osp.dirname(__file__)))
+MMEditing_ROOT = osp.dirname(osp.dirname(__file__))
 
 all_training_data = [
     'div2k', 'celeba', 'places', 'comp1k', 'vimeo90k', 'reds', 'ffhq', 'cufed',


### PR DESCRIPTION

## Motivation

In mmediting master branch "update_model_index.py" locates in ".dev_scripts/github" while in dev-1.x and 1.x branch it locates in ".dev_scripts" . Before python 3.9 "\_\_file\_\_" uses a relative path and pre-commit  runs well. In python 3.9 "\_\_file\_\_" uses an absolute path resulting in pre-commit error. 

## Modification

Correct the path to enable pre-commit runs well in python 3.9

## Who can help? @ them here!

The ones who use python3.9

## Checklist

**Before PR**:

- [ ] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmediting/blob/master/.github/CONTRIBUTING.md) to create this PR.
- [ ] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmediting/blob/master/.github/CONTRIBUTING.md) are used to fix the potential lint issues.
- [ ] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with some of those projects.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
