### PR TITLE
[Enhanchment] Fix unit test of EG3D Render for torch < 1.8.0

### DIFF
--- a/mmedit/models/editors/eg3d/renderer.py
+++ b/mmedit/models/editors/eg3d/renderer.py
@@ -8,6 +8,8 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 from mmengine.model import BaseModule
+from mmengine.utils import digit_version
+from mmengine.utils.dl_utils import TORCH_VERSION
 
 from ..stylegan3.stylegan3_modules import FullyConnectedLayer
 from .eg3d_utils import (get_ray_limits_box, inverse_transform_sampling,
@@ -431,7 +433,10 @@ class EG3DRenderer(BaseModule):
         composite_depth = torch.sum(weights * depths_mid, -2) / weight_total
 
         # clip the composite to min/max range of depths
-        composite_depth = torch.nan_to_num(composite_depth, float('inf'))
+        if digit_version(TORCH_VERSION) < digit_version('1.8.0'):
+            composite_depth[torch.isnan(composite_depth)] = float('inf')
+        else:
+            composite_depth = torch.nan_to_num(composite_depth, float('inf'))
         composite_depth = torch.clamp(composite_depth, torch.min(depths),
                                       torch.max(depths))
 

--- a/tests/test_models/test_editors/test_eg3d/test_camera.py
+++ b/tests/test_models/test_editors/test_eg3d/test_camera.py
@@ -2,6 +2,7 @@
 import math
 from copy import deepcopy
 from unittest import TestCase
+from unittest.mock import patch
 
 import torch
 from mmengine.testing import assert_allclose
@@ -110,6 +111,14 @@ class TestBaseCamera(TestCase):
         camera = BaseCamera(**cfg_)
         cam2world = camera.sample_camera2world()
         self.assertEqual(cam2world.shape, (1, 4, 4))
+
+        mock_path = 'mmedit.models.editors.eg3d.camera.TORCH_VERSION'
+        with patch(mock_path, '1.6.0'):
+            print(torch.__version__)
+            cfg_ = deepcopy(self.default_cfg)
+            camera = BaseCamera(**cfg_)
+            cam2world = camera.sample_camera2world()
+            self.assertEqual(cam2world.shape, (1, 4, 4))
 
     def test_sample_in_range(self):
         cfg_ = deepcopy(self.default_cfg)

--- a/tests/test_models/test_editors/test_eg3d/test_renderer.py
+++ b/tests/test_models/test_editors/test_eg3d/test_renderer.py
@@ -97,3 +97,14 @@ class TestEG3DRenderer(TestCase):
                 ray_directions,
                 render_kwargs=render_kwargs)
             mock_func.assert_called_once()
+
+        # cover TORCH_VERSION < 1.8.0
+        mock_path = 'mmedit.models.editors.eg3d.renderer.TORCH_VERSION'
+        with patch(mock_path, '1.6.0'):
+            cfg_ = deepcopy(self.renderer_cfg)
+            renderer = EG3DRenderer(**cfg_)
+            renderer(
+                plane,
+                ray_origins,
+                ray_directions,
+                render_kwargs=render_kwargs)


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Torch < 1.8.0 does not implement `torch.nan_to_num`.

## Modification

Support nan_to_num for torch < 1.8.0 in EG3D's renderer and add mock in torch version for `test_camera` and `test_renderer` to cover more lines.

## Who can help? @ them here!

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

**Before PR**:

- [x] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmediting/blob/master/.github/CONTRIBUTING.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmediting/blob/master/.github/CONTRIBUTING.md) are used to fix the potential lint issues.
- [x] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [x] If the modification has potential influence on downstream or other related projects, this PR should be tested with some of those projects.
- [x] CLA has been signed and all committers have signed the CLA in this PR.
