### PR TITLE
[Fix] skip restorer's unit test when torch <= 1.5.1

### DIFF
--- a/tests/test_models/test_restorers/test_basic_restorer.py
+++ b/tests/test_models/test_restorers/test_basic_restorer.py
@@ -140,7 +140,7 @@ def test_basic_restorer():
         # evaluation with metrics must have gt images
         restorer(lq=inputs, test_mode=True)
 
-    if version.parse(torch.__version__) <= version.parse('1.5.1'):
+    if version.parse(torch.__version__) > version.parse('1.5.1'):
         with tempfile.TemporaryDirectory() as tmpdir:
             outputs = restorer(
                 **data_batch,


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

`torch <= 1.5.1` do not support interpolation on `torch.uint8`. Therefore we skip unit tests related to inception network when `torch <= 1.5.1`.

## Modification

As title.

## Who can help? @ them here!

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

**Before PR**:

- [x] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmediting/blob/master/.github/CONTRIBUTING.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmediting/blob/master/.github/CONTRIBUTING.md) are used to fix the potential lint issues.
- [x] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [x] If the modification has potential influence on downstream or other related projects, this PR should be tested with some of those projects.
- [x] CLA has been signed and all committers have signed the CLA in this PR.
