### PR TITLE
[Fix] fix dtype of pytorch2onnx

### DIFF
--- a/tools/model_converters/pytorch2onnx.py
+++ b/tools/model_converters/pytorch2onnx.py
@@ -54,7 +54,7 @@ def pytorch2onnx(model,
         data = torch.cat((merged, trimap), dim=1).float()
         data = model.resize_inputs(data)
     elif model_type == 'image_restorer':
-        data = input['inputs'].unsqueeze(0)
+        data = input['inputs'].unsqueeze(0).float()
     elif model_type == 'inpainting':
         masks = input['data_samples'].mask.data.unsqueeze(0)
         img = input['inputs'].unsqueeze(0)


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Fix the error `RuntimeError: "upsample_bicubic2d" not implemented for 'Byte'`

## Modification

Please briefly describe what modification is made in this PR.

## Who can help? @ them here!

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

**Before PR**:

- [ ] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmediting/blob/master/.github/CONTRIBUTING.md) to create this PR.
- [ ] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmediting/blob/master/.github/CONTRIBUTING.md) are used to fix the potential lint issues.
- [ ] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with some of those projects.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
