### PR TITLE
[Fix] dynamic exportable pixel unshuffle

### DIFF
--- a/mmedit/models/common/downsample.py
+++ b/mmedit/models/common/downsample.py
@@ -1,7 +1,4 @@
 # Copyright (c) OpenMMLab. All rights reserved.
-import torch
-
-
 def pixel_unshuffle(x, scale):
     """Down-sample by pixel unshuffle.
 
@@ -20,7 +17,6 @@ def pixel_unshuffle(x, scale):
             f'with shape: {x.shape}')
     h = h // scale
     w = w // scale
-    size = torch.Size([b, c, h, scale, w, scale])
-    x = x.view(size)
+    x = x.view([b, c, h, scale, w, scale])
     x = x.permute(0, 1, 3, 5, 2, 4)
     return x.reshape(b, -1, h, w)

--- a/mmedit/models/common/downsample.py
+++ b/mmedit/models/common/downsample.py
@@ -1,4 +1,7 @@
 # Copyright (c) OpenMMLab. All rights reserved.
+import torch
+
+
 def pixel_unshuffle(x, scale):
     """Down-sample by pixel unshuffle.
 
@@ -15,8 +18,8 @@ def pixel_unshuffle(x, scale):
         raise AssertionError(
             f'Invalid scale ({scale}) of pixel unshuffle for tensor '
             f'with shape: {x.shape}')
-    h = int(h / scale)
-    w = int(w / scale)
+    h = torch.div(h, scale, rounding_mode='floor')
+    w = torch.div(w, scale, rounding_mode='floor')
     x = x.view(b, c, h, scale, w, scale)
     x = x.permute(0, 1, 3, 5, 2, 4)
     return x.reshape(b, -1, h, w)

--- a/mmedit/models/common/downsample.py
+++ b/mmedit/models/common/downsample.py
@@ -18,8 +18,9 @@ def pixel_unshuffle(x, scale):
         raise AssertionError(
             f'Invalid scale ({scale}) of pixel unshuffle for tensor '
             f'with shape: {x.shape}')
-    h = torch.div(h, scale, rounding_mode='floor')
-    w = torch.div(w, scale, rounding_mode='floor')
-    x = x.view(b, c, h, scale, w, scale)
+    h = h // scale
+    w = w // scale
+    size = torch.Size([b, c, h, scale, w, scale])
+    x = x.view(size)
     x = x.permute(0, 1, 3, 5, 2, 4)
     return x.reshape(b, -1, h, w)

--- a/mmedit/models/common/downsample.py
+++ b/mmedit/models/common/downsample.py
@@ -17,6 +17,6 @@ def pixel_unshuffle(x, scale):
             f'with shape: {x.shape}')
     h = h // scale
     w = w // scale
-    x = x.view([b, c, h, scale, w, scale])
+    x = x.view(b, c, h, scale, w, scale)
     x = x.permute(0, 1, 3, 5, 2, 4)
     return x.reshape(b, -1, h, w)


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

These are changes to support pixel unshuffling for inputs of various sizes during onnx export. The warning is as follows:
```
/opt/conda/lib/python3.8/site-packages/mmedit/models/common/downsample.py:14: TracerWarning: Converting a tensor to a Python boolean might cause the trace to be incorrect. We can't record the data flow of Python values, so this value will be treated as a constant in the future. This means that the trace might not generalize to other inputs!
  if h % scale != 0 or w % scale != 0:
/opt/conda/lib/python3.8/site-packages/mmedit/models/common/downsample.py:18: TracerWarning: Converting a tensor to a Python integer might cause the trace to be incorrect. We can't record the data flow of Python values, so this value will be treated as a constant in the future. This means that the trace might not generalize to other inputs!
  h = int(h / scale)
/opt/conda/lib/python3.8/site-packages/mmedit/models/common/downsample.py:19: TracerWarning: Converting a tensor to a Python integer might cause the trace to be incorrect. We can't record the data flow of Python values, so this value will be treated as a constant in the future. This means that the trace might not generalize to other inputs!
  w = int(w / scale)
```

More detail could be found in here:
https://pytorch.org/docs/stable/onnx.html#avoid-numpy-and-built-in-python-types

## Modification

Please briefly describe what modification is made in this PR.

## Who can help? @ them here!

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

**Before PR**:

- [ ] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmediting/blob/master/.github/CONTRIBUTING.md) to create this PR.
- [ ] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmediting/blob/master/.github/CONTRIBUTING.md) are used to fix the potential lint issues.
- [ ] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with some of those projects.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
