### PR TITLE
[Fix] fix import error in quick run demo doc

### DIFF
--- a/docs/en/get_started/quick_run.md
+++ b/docs/en/get_started/quick_run.md
@@ -34,7 +34,7 @@ you only need several lines of codes for image super-resolution by MMEditing!
 ```python
 import mmcv
 from mmedit.apis import init_model, restoration_inference
-from mmedit.engine.misc import tensor2img
+from mmedit.utils import tensor2img
 
 config = 'configs/esrgan/esrgan_x4c64b23g32_1xb16-400k_div2k.py'
 checkpoint = 'https://download.openmmlab.com/mmediting/restorers/esrgan/esrgan_x4c64b23g32_1x16_400k_div2k_20200508-f8ccaf3b.pth'


### PR DESCRIPTION
### Error info:
```
❯ PYTHONPATH='.'$PYTHONPATH python quick_run.py
╭─────────────────────────────── Traceback (most recent call last) ────────────────────────────────╮
│ /home/lqy/Desktop/mmediting/quick_run.py:3 in <module>                                           │
│                                                                                                  │
│    1 import mmcv                                                                                 │
│    2 from mmedit.apis import init_model, restoration_inference                                   │
│ ❱  3 from mmedit.engine.misc import tensor2img                                                   │
│    4                                                                                             │
│    5 config = 'configs/esrgan/esrgan_x4c64b23g32_1xb16-400k_div2k.py'                            │
│    6 checkpoint = 'https://download.openmmlab.com/mmediting/restorers/esrgan/esrgan_x4c64b23g    │
╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
```