### PR TITLE
[Fix] fix dataset_converters scripts int arg passing bug

### DIFF
--- a/tools/dataset_converters/df2k_ost/preprocess_df2k_ost_dataset.py
+++ b/tools/dataset_converters/df2k_ost/preprocess_df2k_ost_dataset.py
@@ -307,23 +307,31 @@ def parse_args():
     parser.add_argument('--data-root', help='dataset root')
     parser.add_argument(
         '--crop-size',
+        type=int,
         nargs='?',
         default=480,
         help='cropped size for HR images')
     parser.add_argument(
-        '--step', nargs='?', default=240, help='step size for HR images')
+        '--step',
+        type=int,
+        nargs='?',
+        default=240,
+        help='step size for HR images')
     parser.add_argument(
         '--thresh-size',
+        type=int,
         nargs='?',
         default=0,
         help='threshold size for HR images')
     parser.add_argument(
         '--compression-level',
+        type=int,
         nargs='?',
         default=3,
         help='compression level when save png images')
     parser.add_argument(
         '--n-thread',
+        type=int,
         nargs='?',
         default=20,
         help='thread number when using multiprocessing')

--- a/tools/dataset_converters/div2k/preprocess_div2k_dataset.py
+++ b/tools/dataset_converters/div2k/preprocess_div2k_dataset.py
@@ -373,11 +373,13 @@ def parse_args():
         '--thresh-size',
         nargs='?',
         default=0,
+        type=int,
         help='threshold size for HR images')
     parser.add_argument(
         '--compression-level',
         nargs='?',
         default=3,
+        type=int,
         help='compression level when save png images')
     parser.add_argument(
         '--n-thread',

--- a/tools/dataset_converters/reds/crop_sub_images.py
+++ b/tools/dataset_converters/reds/crop_sub_images.py
@@ -158,23 +158,31 @@ def parse_args():
         '--scales', nargs='*', default=[], help='scale factor list')
     parser.add_argument(
         '--crop-size',
+        type=int,
         nargs='?',
         default=480,
         help='cropped size for HR images')
     parser.add_argument(
-        '--step', nargs='?', default=240, help='step size for HR images')
+        '--step',
+        type=int,
+        nargs='?',
+        default=240,
+        help='step size for HR images')
     parser.add_argument(
         '--thresh-size',
+        type=int,
         nargs='?',
         default=0,
         help='threshold size for HR images')
     parser.add_argument(
         '--compression-level',
+        type=int,
         nargs='?',
         default=3,
         help='compression level when save png images')
     parser.add_argument(
         '--n-thread',
+        type=int,
         nargs='?',
         default=20,
         help='thread number when using multiprocessing')


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

There are several scripts under tools/dataset_converters accpet int arguments, e.g., '--n-thread'. However, some of those arguments are not declared as int explicitly,  they will be regarded as str if we pass those arguments to the scripts by ourselves, and therefore generate an error message in the following steps.

## Modification

Define the int arguments with type=int explicitly in those buggy scripts under tools/dataset_converters.

## Who can help? @ them here!

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

**Before PR**:

- [x] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmediting/blob/master/.github/CONTRIBUTING.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmediting/blob/master/.github/CONTRIBUTING.md) are used to fix the potential lint issues.
- [x] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [x] If the modification has potential influence on downstream or other related projects, this PR should be tested with some of those projects.
- [x] CLA has been signed and all committers have signed the CLA in this PR.
