### PR TITLE
[Fix] Use LongTensor in index_select for pt16

### DIFF
--- a/mmedit/models/data_preprocessors/edit_data_preprocessor.py
+++ b/mmedit/models/data_preprocessors/edit_data_preprocessor.py
@@ -295,7 +295,7 @@ class EditDataPreprocessor(ImgDataPreprocessor):
             # do conversion
             inputs = torch.index_select(
                 inputs, channel_index,
-                torch.IntTensor(new_index).to(inputs.device))
+                torch.LongTensor(new_index).to(inputs.device))
             return inputs
 
         channel_index = self._parse_channel_index(inputs)


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Pytorch 1.6 do not support int32 as index in `index_select`. This PR adopts index to `int64` (`LongTensor`) to pass the unit test.

## Modification

As title.

## Who can help? @ them here!

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

**Before PR**:

- [x] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmediting/blob/master/.github/CONTRIBUTING.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmediting/blob/master/.github/CONTRIBUTING.md) are used to fix the potential lint issues.
- [x] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [x] If the modification has potential influence on downstream or other related projects, this PR should be tested with some of those projects.
- [x] CLA has been signed and all committers have signed the CLA in this PR.
