### PR TITLE
Make the image order in VisualizationHook as it is in the config

### DIFF
--- a/mmedit/core/hooks/visualization.py
+++ b/mmedit/core/hooks/visualization.py
@@ -72,7 +72,7 @@ class MMEditVisualizationHook(Hook):
 
         filename = self.filename_tmpl.format(runner.iter + 1)
 
-        img_list = [x for k, x in results.items() if k in self.res_name_list]
+        img_list = [results[k] for k in self.res_name_list if k in results]
         img_cat = torch.cat(img_list, dim=3).detach()
         if self.rerange:
             img_cat = ((img_cat + 1) / 2)

--- a/tools/train.py
+++ b/tools/train.py
@@ -104,6 +104,8 @@ def main():
 
     # create work_dir
     mmcv.mkdir_or_exist(osp.abspath(cfg.work_dir))
+    # dump config
+    cfg.dump(osp.join(cfg.work_dir, osp.basename(args.config)))
     # init the logger before other steps
     timestamp = time.strftime('%Y%m%d_%H%M%S', time.localtime())
     log_file = osp.join(cfg.work_dir, f'{timestamp}.log')


### PR DESCRIPTION
## Motivation

Save visual images according to the order in the config.

Currently the images are concatenated according to the order in the results dict, and the order is not configurable:


<https://github.com/open-mmlab/mmediting/blob/d18fc44868082b3bff4d80973b09b1f2f2db88a3/mmedit/core/hooks/visualization.py#L75>

I changed this line to 

```
img_list = [results[k] for k in self.res_name_list if k in results]
```
so that we can configure the order of images being saved using  `visual_config.res_name_list`.
