### PR TITLE
Corrected iterator counting logic of sampler

### DIFF
--- a/mmedit/utils/sampler.py
+++ b/mmedit/utils/sampler.py
@@ -83,7 +83,7 @@ class NoiseSampler:
         return self
 
     def __next__(self):
-        if self.idx > self.max_times:
+        if self.idx >= self.max_times:
             raise StopIteration
         self.idx += 1
 
@@ -116,7 +116,7 @@ class DataSampler:
         return self
 
     def __next__(self):
-        if self.idx > self.max_times:
+        if self.idx >= self.max_times:
             self._iterator = iter(self._dataloader)
             raise StopIteration
         self.idx += 1
@@ -152,7 +152,7 @@ class ValDataSampler:
         return self
 
     def __next__(self):
-        if self.idx > self.max_times:
+        if self.idx >= self.max_times:
             self._iterator = iter(self._dataloader)
             raise StopIteration
         self.idx += 1

--- a/tests/test_utils/test_sampler.py
+++ b/tests/test_utils/test_sampler.py
@@ -62,3 +62,10 @@ def test_val_data_sampler():
     assert len(val_sampler._dataloader.dataset) == 8
     for idx, out in enumerate(val_sampler):
         assert out == tar_out[idx]
+
+    # test iteration times
+    val_sampler = ValDataSampler(
+        sample_kwargs=dict(max_times=1), runner=runner)
+    tar_out = [[0, 1, 2, 3]]
+    for idx, out in enumerate(val_sampler):
+        assert out == tar_out[idx]


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

The original count logic of samplers are wrong and causes one more loop in visualization.

## Modification

Revise the counting logic.

## Who can help? @ them here!

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

**Before PR**:

- [x] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmediting/blob/master/.github/CONTRIBUTING.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmediting/blob/master/.github/CONTRIBUTING.md) are used to fix the potential lint issues.
- [x] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [x] If the modification has potential influence on downstream or other related projects, this PR should be tested with some of those projects.
- [x] CLA has been signed and all committers have signed the CLA in this PR.
