### PR TITLE
[Enhancement] Support string type (prompt) in EditDataSample

### DIFF
--- a/mmedit/structures/edit_data_sample.py
+++ b/mmedit/structures/edit_data_sample.py
@@ -3,7 +3,7 @@ from collections import abc
 from copy import deepcopy
 from itertools import chain
 from numbers import Number
-from typing import Any, List, Sequence, Union
+from typing import Any, Sequence, Union
 
 import mmengine
 import numpy as np
@@ -204,7 +204,7 @@ class EditDataSample(BaseDataElement):
             if k == 'gt_label':
                 self.set_gt_label(v)
             elif k == 'prompt':
-                self.set_prompt(v)
+                self.set_field(v, k, dtype=(str, list))
             else:
                 self.set_field(all_to_tensor(v), k, dtype=torch.Tensor)
 
@@ -241,32 +241,6 @@ class EditDataSample(BaseDataElement):
     def gt_label(self):
         """Delete gt label."""
         del self._gt_label
-
-    def set_prompt(self, value):
-        self.prompt = value
-
-    @property
-    def prompt(self):
-        """This is function to fetch prompt.
-
-        Returns:
-            Union[str, list]: A prompt or a list of prompts (if stacked).
-        """
-        return self._prompt
-
-    @prompt.setter
-    def prompt(self, value: Union[str, List[str]]):
-        """This is the function to set prompt.
-
-        Args:
-            value (Union[str, List[str]]): A prompt or a list of prompts.
-        """
-        self.set_field(value, '_prompt', dtype=(str, list))
-
-    @prompt.deleter
-    def prompt(self):
-        """This is the function to delete prompt."""
-        del self._prompt
 
     @classmethod
     def stack(cls,

--- a/mmedit/structures/edit_data_sample.py
+++ b/mmedit/structures/edit_data_sample.py
@@ -3,7 +3,7 @@ from collections import abc
 from copy import deepcopy
 from itertools import chain
 from numbers import Number
-from typing import Any, Sequence, Union
+from typing import Any, List, Sequence, Union
 
 import mmengine
 import numpy as np
@@ -28,7 +28,6 @@ def format_label(value: Union[torch.Tensor, np.ndarray, Sequence, int],
     Returns:
         :obj:`mmengine.LabelData`: The foramtted label data.
     """
-
     # Handle single number
     if isinstance(value, (torch.Tensor, np.ndarray)) and value.ndim == 0:
         value = int(value.item())
@@ -165,7 +164,9 @@ class EditDataSample(BaseDataElement):
         'gray': 'gray',
         'cropped_img': 'cropped_img',
         'pred_img': 'pred_img',
-        'ori_trimap': 'ori_trimap'
+        'ori_trimap': 'ori_trimap',
+        # For text to images
+        'prompt': 'prompt'
     }
 
     def set_predefined_data(self, data: dict) -> None:
@@ -202,6 +203,8 @@ class EditDataSample(BaseDataElement):
         for k, v in data.items():
             if k == 'gt_label':
                 self.set_gt_label(v)
+            elif k == 'prompt':
+                self.set_prompt(v)
             else:
                 self.set_field(all_to_tensor(v), k, dtype=torch.Tensor)
 
@@ -238,6 +241,32 @@ class EditDataSample(BaseDataElement):
     def gt_label(self):
         """Delete gt label."""
         del self._gt_label
+
+    def set_prompt(self, value):
+        self.prompt = value
+
+    @property
+    def prompt(self):
+        """This is function to fetch prompt.
+
+        Returns:
+            Union[str, list]: A prompt or a list of prompts (if stacked).
+        """
+        return self._prompt
+
+    @prompt.setter
+    def prompt(self, value: Union[str, List[str]]):
+        """This is the function to set prompt.
+
+        Args:
+            value (Union[str, List[str]]): A prompt or a list of prompts.
+        """
+        self.set_field(value, '_prompt', dtype=(str, list))
+
+    @prompt.deleter
+    def prompt(self):
+        """This is the function to delete prompt."""
+        del self._prompt
 
     @classmethod
     def stack(cls,

--- a/tests/test_structures/test_edit_data_sample.py
+++ b/tests/test_structures/test_edit_data_sample.py
@@ -61,6 +61,7 @@ class TestEditDataSample(TestCase):
         # METAINFO
         img_path, gt_path, merged_path = 'aaa', 'bbb', 'ccc'
         gt_channel_order, gt_color_type = 'rgb', 'color'
+        prompt = 'prompt'
 
         data = dict(
             gt=gt,
@@ -74,7 +75,8 @@ class TestEditDataSample(TestCase):
             gt_path=gt_path,
             merged_path=merged_path,
             gt_channel_order=gt_channel_order,
-            gt_color_type=gt_color_type)
+            gt_color_type=gt_color_type,
+            prompt=prompt)
         data_sample = EditDataSample()
         data_sample.set_predefined_data(data)
 
@@ -91,6 +93,7 @@ class TestEditDataSample(TestCase):
                                 gt_channel_order, True)
         self._check_in_and_same(data_sample, 'gt_color_type', gt_color_type,
                                 True)
+        self._check_in_and_same(data_sample, 'prompt', prompt, False)
         # check gt label
         data_sample.gt_label.data = gt_label
 
@@ -175,6 +178,19 @@ class TestEditDataSample(TestCase):
         self.assertIn('gt_label', data_sample)
         del data_sample.gt_label
         self.assertNotIn('gt_label', data_sample)
+
+    def test_set_prompt(self):
+        data_sample = EditDataSample()
+        prompt = 'I\'m a prompt!'
+        data_sample.set_prompt(prompt)
+        self.assertEqual(data_sample.prompt, prompt)
+
+        del data_sample.prompt
+        self.assertNotIn('prompt', data_sample)
+
+        prompts = ['I\'m a prompt!', 'I\'m another prompt!']
+        data_sample.set_prompt(prompts)
+        self.assertEqual(data_sample.prompt, prompts)
 
     def test_stack_and_split(self):
         # test stack

--- a/tests/test_structures/test_edit_data_sample.py
+++ b/tests/test_structures/test_edit_data_sample.py
@@ -179,25 +179,13 @@ class TestEditDataSample(TestCase):
         del data_sample.gt_label
         self.assertNotIn('gt_label', data_sample)
 
-    def test_set_prompt(self):
-        data_sample = EditDataSample()
-        prompt = 'I\'m a prompt!'
-        data_sample.set_prompt(prompt)
-        self.assertEqual(data_sample.prompt, prompt)
-
-        del data_sample.prompt
-        self.assertNotIn('prompt', data_sample)
-
-        prompts = ['I\'m a prompt!', 'I\'m another prompt!']
-        data_sample.set_prompt(prompts)
-        self.assertEqual(data_sample.prompt, prompts)
-
     def test_stack_and_split(self):
         # test stack
         data_sample1 = EditDataSample()
         data_sample1.set_gt_label(1)
         data_sample1.set_tensor_data({'img': torch.randn(3, 4, 5)})
         data_sample1.set_data({'mode': 'a'})
+        data_sample1.set_data({'prompt': 'I\'m a prompt!'})
         data_sample1.set_metainfo({
             'channel_order': 'rgb',
             'color_flag': 'color'
@@ -206,6 +194,7 @@ class TestEditDataSample(TestCase):
         data_sample2.set_gt_label(2)
         data_sample2.set_tensor_data({'img': torch.randn(3, 4, 5)})
         data_sample2.set_data({'mode': 'b'})
+        data_sample2.set_data({'prompt': 'I\'m an another prompt!'})
         data_sample2.set_metainfo({
             'channel_order': 'rgb',
             'color_flag': 'color'
@@ -220,6 +209,9 @@ class TestEditDataSample(TestCase):
         assert data_sample_merged.metainfo == dict(
             channel_order=['rgb', 'rgb'], color_flag=['color', 'color'])
         assert len(data_sample_merged) == 2
+        assert data_sample_merged.prompt == [
+            'I\'m a prompt!', 'I\'m an another prompt!'
+        ]
 
         # test split
         data_sample_merged.sample_model = 'ema'
@@ -241,6 +233,8 @@ class TestEditDataSample(TestCase):
         assert data_splited_2.sample_model == 'ema'
         assert data_splited_1.fake_img.img.shape == (3, 4, 4)
         assert data_splited_2.fake_img.img.shape == (3, 4, 4)
+        assert data_splited_1.prompt == 'I\'m a prompt!'
+        assert data_splited_2.prompt == 'I\'m an another prompt!'
 
         with self.assertRaises(TypeError):
             data_sample_merged.split()
@@ -250,6 +244,7 @@ class TestEditDataSample(TestCase):
         data_sample.set_gt_label(3)
         data_sample.set_tensor_data({'img': torch.randn(3, 4, 5)})
         data_sample.set_data({'mode': 'c'})
+        data_sample.set_data({'prompt': 'proooommmmpt'})
         data_sample.set_metainfo({
             'channel_order': 'rgb',
             'color_flag': 'color'
@@ -262,6 +257,7 @@ class TestEditDataSample(TestCase):
         assert data_sample_merged.mode == ['c']
         assert data_sample_merged.metainfo == dict(
             channel_order=['rgb'], color_flag=['color'])
+        data_sample_merged.prompt == ['proooommmmpt']
         assert len(data_sample_merged) == 1
 
         # test split
@@ -270,6 +266,7 @@ class TestEditDataSample(TestCase):
         data_splited = data_splited[0]
         assert (data_splited.gt_label.label == 3).all()
         assert (data_splited.img == data_sample.img).all()
+        assert data_splited.prompt == 'proooommmmpt'
         assert (data_splited.metainfo == dict(
             channel_order='rgb', color_flag='color'))
 


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Text-to-image tasks need text prompts, which are `str` type, as input. Therefore we support an additional attribute called `prompt` for `EditDataSample`.

## Modification

Add `prompt` attribute for `EditDataSample`.

## Who can help? @ them here!

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

**Before PR**:

- [x] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmediting/blob/master/.github/CONTRIBUTING.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmediting/blob/master/.github/CONTRIBUTING.md) are used to fix the potential lint issues.
- [x] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [x] If the modification has potential influence on downstream or other related projects, this PR should be tested with some of those projects.
- [x] CLA has been signed and all committers have signed the CLA in this PR.
