### PR TITLE
[Enhancement] Revise StableDiffusion and corresponding components

### DIFF
--- a/configs/stable_diffusion/stable-diffusion_ddim_denoisingunet.py
+++ b/configs/stable_diffusion/stable-diffusion_ddim_denoisingunet.py
@@ -20,6 +20,7 @@ unet = dict(
     output_cfg=dict(var='fixed'))
 
 vae = dict(
+    type='EditAutoencoderKL',
     act_fn='silu',
     block_out_channels=[128, 256, 512, 512],
     down_block_types=[
@@ -47,12 +48,15 @@ diffusion_scheduler = dict(
     set_alpha_to_one=False,
     clip_sample=False)
 
-init_cfg = dict(type='Pretrained', pretrained_model_path='')
-
 model = dict(
     type='StableDiffusion',
-    diffusion_scheduler=diffusion_scheduler,
     unet=unet,
     vae=vae,
-    init_cfg=init_cfg,
-)
+    text_encoder=dict(
+        type='ClipWrapper',
+        clip_type='huggingface',
+        pretrained_model_name_or_path='runwayml/stable-diffusion-v1-5',
+        subfolder='text_encoder'),
+    tokenizer='runwayml/stable-diffusion-v1-5',
+    scheduler=diffusion_scheduler,
+    test_scheduler=diffusion_scheduler)

--- a/mmedit/models/data_preprocessors/edit_data_preprocessor.py
+++ b/mmedit/models/data_preprocessors/edit_data_preprocessor.py
@@ -758,8 +758,6 @@ class EditDataPreprocessor(ImgDataPreprocessor):
         if data_samples is None:
             return batch_tensor
 
-        # import ipdb
-        # ipdb.set_trace()
         if isinstance(data_samples, list):
             is_batch_data = True
             if 'padding_size' in data_samples[0].metainfo_keys():
@@ -794,8 +792,6 @@ class EditDataPreprocessor(ImgDataPreprocessor):
                     WARNING)
             return batch_tensor if is_batch_data else batch_tensor[0]
 
-        # import ipdb
-        # ipdb.set_trace()
         if same_padding:
             # un-pad with the padding info of the first sample
             padded_h, padded_w = pad_infos[0][-2:]

--- a/mmedit/models/diffusion_schedulers/__init__.py
+++ b/mmedit/models/diffusion_schedulers/__init__.py
@@ -7,6 +7,28 @@ from .ddim_scheduler import EditDDIMScheduler
 from .ddpm_scheduler import EditDDPMScheduler
 
 
+class SchedulerWrapper:
+
+    def __init__(self, from_pretrained=None, *args, **kwargs):
+
+        scheduler_cls = self._scheduler_cls
+
+        self._from_pretrained = from_pretrained
+        if self._from_pretrained:
+            self.scheduler = scheduler_cls.from_pretrained(
+                from_pretrained, *args, **kwargs)
+        else:
+            self.scheduler = scheduler_cls(*args, **kwargs)
+
+    def __getattr__(self, name):
+        try:
+            return getattr(self.scheduler, name)
+        except AttributeError:
+            raise AttributeError('\'name\' cannot be found in both '
+                                 f'\'{self.__class__.__name__}\' and '
+                                 f'\'{self.__class__.__name__}.scheduler\'.')
+
+
 def register_diffusers_schedulers() -> List[str]:
     """Register schedulers in ``diffusers.schedulers`` to the
     ``DIFFUSION_SCHEDULERS`` registry. Specifically, the registered schedulers
@@ -30,6 +52,14 @@ def register_diffusers_schedulers() -> List[str]:
                       'please install diffusers>=0.12.0.')
         return None
 
+    def gen_wrapped_cls(scheduler, scheduler_name):
+        return type(
+            scheduler_name, (SchedulerWrapper, ),
+            dict(
+                _scheduler_cls=scheduler,
+                _scheduler_name=scheduler_name,
+                __module__=__name__))
+
     DIFFUSERS_SCHEDULERS = []
     for module_name in dir(diffusers.schedulers):
         if module_name.startswith('Flax'):
@@ -37,8 +67,9 @@ def register_diffusers_schedulers() -> List[str]:
         elif module_name.endswith('Scheduler'):
             _scheduler = getattr(diffusers.schedulers, module_name)
             if inspect.isclass(_scheduler):
+                wrapped_scheduler = gen_wrapped_cls(_scheduler, module_name)
                 DIFFUSION_SCHEDULERS.register_module(
-                    name=module_name, module=_scheduler)
+                    name=module_name, module=wrapped_scheduler)
                 DIFFUSERS_SCHEDULERS.append(module_name)
     return DIFFUSERS_SCHEDULERS
 

--- a/mmedit/models/diffusion_schedulers/ddim_scheduler.py
+++ b/mmedit/models/diffusion_schedulers/ddim_scheduler.py
@@ -1,5 +1,5 @@
 # Copyright (c) OpenMMLab. All rights reserved.
-from typing import Union
+from typing import Optional, Union
 
 import numpy as np
 import torch
@@ -77,6 +77,9 @@ class EditDDIMScheduler:
         self.final_alpha_cumprod = np.array(
             1.0) if set_alpha_to_one else self.alphas_cumprod[0]
 
+        # standard deviation of the initial noise distribution
+        self.init_noise_sigma = 1.0
+
         # setable values
         self.num_inference_steps = None
         self.timesteps = np.arange(0, num_train_timesteps)[::-1].copy()
@@ -89,6 +92,22 @@ class EditDDIMScheduler:
             0, self.num_train_timesteps,
             self.num_train_timesteps // self.num_inference_steps)[::-1].copy()
         self.timesteps += offset
+
+    def scale_model_input(self,
+                          sample: torch.FloatTensor,
+                          timestep: Optional[int] = None) -> torch.FloatTensor:
+        """Ensures interchangeability with schedulers that need to scale the
+        denoising model input depending on the current timestep.
+
+        Args:
+            sample (`torch.FloatTensor`): input sample
+            timestep (`int`, optional): current timestep
+
+        Returns:
+            `torch.FloatTensor`: scaled input sample
+        """
+
+        return sample
 
     def _get_variance(self, timestep, prev_timestep):
         """get variance."""

--- a/mmedit/models/editors/ddpm/denoising_unet.py
+++ b/mmedit/models/editors/ddpm/denoising_unet.py
@@ -1132,6 +1132,9 @@ class DenoisingUnet(BaseModule):
                 bias=True,
                 order=('norm', 'act', 'conv'))
 
+        if self.unet_type == 'stable':
+            self.sample_size = 64
+
         self.init_weights(pretrained)
 
     def forward(self,

--- a/mmedit/models/editors/ddpm/denoising_unet.py
+++ b/mmedit/models/editors/ddpm/denoising_unet.py
@@ -1133,7 +1133,7 @@ class DenoisingUnet(BaseModule):
                 order=('norm', 'act', 'conv'))
 
         if self.unet_type == 'stable':
-            self.sample_size = 64
+            self.sample_size = image_size
 
         self.init_weights(pretrained)
 

--- a/mmedit/models/editors/ddpm/denoising_unet.py
+++ b/mmedit/models/editors/ddpm/denoising_unet.py
@@ -1133,7 +1133,7 @@ class DenoisingUnet(BaseModule):
                 order=('norm', 'act', 'conv'))
 
         if self.unet_type == 'stable':
-            self.sample_size = image_size
+            self.sample_size = image_size // 8  # NOTE: hard code here
 
         self.init_weights(pretrained)
 
@@ -1278,7 +1278,7 @@ class DenoisingUnet(BaseModule):
             h = h.type(x_t.dtype)
             outputs = self.out(h)
 
-        return {'outputs': outputs}
+        return {'sample': outputs}
 
     def init_weights(self, pretrained=None):
         """Init weights for models.

--- a/mmedit/models/editors/guided_diffusion/adm.py
+++ b/mmedit/models/editors/guided_diffusion/adm.py
@@ -162,7 +162,7 @@ class AblatedDiffusionModel(BaseModel):
             timesteps = tqdm(timesteps)
         for t in timesteps:
             # 1. predicted model_output
-            model_output = self.unet(image, t, label=labels)['outputs']
+            model_output = self.unet(image, t, label=labels)['sample']
 
             # 2. compute previous image: x_t -> x_t-1
             if classifier_scale > 0 and self.classifier is not None:

--- a/mmedit/models/editors/stable_diffusion/__init__.py
+++ b/mmedit/models/editors/stable_diffusion/__init__.py
@@ -1,4 +1,5 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 from .stable_diffusion import StableDiffusion
+from .vae import AutoencoderKL
 
-__all__ = ['StableDiffusion']
+__all__ = ['StableDiffusion', 'AutoencoderKL']

--- a/mmedit/models/editors/stable_diffusion/stable_diffusion.py
+++ b/mmedit/models/editors/stable_diffusion/stable_diffusion.py
@@ -147,10 +147,9 @@ class StableDiffusion(BaseModel):
                 will be returned. Defaults to 'image'.
 
         Returns:
-            dict:['samples', 'nsfw_content_detected']:
-                'samples': image result samples
-                'nsfw_content_detected': nsfw content flags for image samples.
+            dict: A dict containing the generated images.
         """
+        assert return_type in ['image', 'tensor', 'numpy']
         set_random_seed(seed=seed)
 
         # 0. Default height and width to unet
@@ -210,7 +209,7 @@ class StableDiffusion(BaseModel):
             # predict the noise residual
             noise_pred = self.unet(
                 latent_model_input, t,
-                encoder_hidden_states=text_embeddings)['outputs']
+                encoder_hidden_states=text_embeddings)['sample']
 
             # perform guidance
             if do_classifier_free_guidance:
@@ -223,7 +222,7 @@ class StableDiffusion(BaseModel):
                     noise_pred, t, latents, **extra_step_kwargs)['prev_sample']
 
         # 8. Post-processing
-        image = self.decode_latents(latents)
+        image = self.decode_latents(latents.to(self.vae.dtype))
         if return_type == 'image':
             image = self.output_to_pil(image)
         elif return_type == 'numpy':

--- a/mmedit/models/editors/stable_diffusion/stable_diffusion.py
+++ b/mmedit/models/editors/stable_diffusion/stable_diffusion.py
@@ -40,8 +40,6 @@ class StableDiffusion(BaseModel):
             module for diffusion scheduler in test stage (`self.infer`). If not
             passed, will use the same scheduler as `schedule`. Defaults to
             None.
-        unet_sample_size (int, optional): The sample size for unet.
-            Defaults to None.
         data_preprocessor (dict, optional): The pre-process config of
             :class:`BaseDataPreprocessor`.
         init_cfg (dict, optional): The weight initialized config for
@@ -53,11 +51,11 @@ class StableDiffusion(BaseModel):
                  text_encoder: ModelType,
                  tokenizer: str,
                  unet: ModelType,
-                 scheduler,
-                 test_scheduler=None,
-                 unet_sample_size=None,
-                 data_preprocessor=dict(type='EditDataPreprocessor'),
-                 init_cfg=None):
+                 scheduler: ModelType,
+                 test_scheduler: Optional[ModelType] = None,
+                 data_preprocessor: Optional[ModelType] = dict(
+                     type='EditDataPreprocessor'),
+                 init_cfg: Optional[dict] = None):
 
         # TODO: support `from_pretrained` for this class
         super().__init__(data_preprocessor, init_cfg)
@@ -79,12 +77,7 @@ class StableDiffusion(BaseModel):
             self.tokenizer = CLIPTokenizer.from_pretrained(
                 tokenizer, subfolder='tokenizer')
 
-        # default sample size for unet
-        if hasattr(self.unet, 'sample_size'):
-            self.unet_sample_size = self.unet.sample_size
-        else:
-            self.unet_sample_size = unet_sample_size
-
+        self.unet_sample_size = self.unet.sample_size
         self.vae_scale_factor = 2**(len(self.vae.block_out_channels) - 1)
 
     @property

--- a/mmedit/models/editors/stable_diffusion/vae.py
+++ b/mmedit/models/editors/stable_diffusion/vae.py
@@ -11,6 +11,8 @@ from addict import Dict
 from mmengine.utils.dl_utils import TORCH_VERSION
 from mmengine.utils.version_utils import digit_version
 
+from mmedit.registry import MODELS
+
 
 class Downsample2D(nn.Module):
     """A downsampling layer with an optional convolution.
@@ -874,6 +876,7 @@ class DiagonalGaussianDistribution(object):
         return self.mean
 
 
+@MODELS.register_module('EditAutoencoderKL')
 class AutoencoderKL(nn.Module):
     r"""Variational Autoencoder (VAE) model with KL loss
     from the paper Auto-Encoding Variational Bayes by Diederik P. Kingma

--- a/mmedit/models/editors/stable_diffusion/vae.py
+++ b/mmedit/models/editors/stable_diffusion/vae.py
@@ -947,6 +947,11 @@ class AutoencoderKL(nn.Module):
         self.post_quant_conv = torch.nn.Conv2d(latent_channels,
                                                latent_channels, 1)
 
+    @property
+    def dtype(self):
+        """The data type of the parameters of VAE."""
+        return next(self.parameters()).dtype
+
     def encode(self, x: torch.FloatTensor, return_dict: bool = True) -> Dict:
         """encode input."""
         h = self.encoder(x)

--- a/mmedit/models/utils/__init__.py
+++ b/mmedit/models/utils/__init__.py
@@ -5,7 +5,8 @@ from .flow_warp import flow_warp
 from .model_utils import (build_module, default_init_weights,
                           generation_init_weights, get_module_device,
                           get_valid_noise_size, get_valid_num_batches,
-                          make_layer, set_requires_grad)
+                          make_layer, set_requires_grad, set_xformers,
+                          xformers_is_enable)
 from .sampling_utils import label_sample_fn, noise_sample_fn
 from .tensor_utils import get_unknown_tensor, normalize_vecs
 
@@ -14,5 +15,6 @@ __all__ = [
     'generation_init_weights', 'set_requires_grad', 'extract_bbox_patch',
     'extract_around_bbox', 'get_unknown_tensor', 'noise_sample_fn',
     'label_sample_fn', 'get_valid_num_batches', 'get_valid_noise_size',
-    'get_module_device', 'normalize_vecs', 'build_module'
+    'get_module_device', 'normalize_vecs', 'build_module', 'set_xformers',
+    'xformers_is_enable'
 ]

--- a/mmedit/models/utils/__init__.py
+++ b/mmedit/models/utils/__init__.py
@@ -2,9 +2,10 @@
 
 from .bbox_utils import extract_around_bbox, extract_bbox_patch
 from .flow_warp import flow_warp
-from .model_utils import (default_init_weights, generation_init_weights,
-                          get_module_device, get_valid_noise_size,
-                          get_valid_num_batches, make_layer, set_requires_grad)
+from .model_utils import (build_module, default_init_weights,
+                          generation_init_weights, get_module_device,
+                          get_valid_noise_size, get_valid_num_batches,
+                          make_layer, set_requires_grad)
 from .sampling_utils import label_sample_fn, noise_sample_fn
 from .tensor_utils import get_unknown_tensor, normalize_vecs
 
@@ -13,5 +14,5 @@ __all__ = [
     'generation_init_weights', 'set_requires_grad', 'extract_bbox_patch',
     'extract_around_bbox', 'get_unknown_tensor', 'noise_sample_fn',
     'label_sample_fn', 'get_valid_num_batches', 'get_valid_noise_size',
-    'get_module_device', 'normalize_vecs'
+    'get_module_device', 'normalize_vecs', 'build_module'
 ]

--- a/mmedit/models/utils/model_utils.py
+++ b/mmedit/models/utils/model_utils.py
@@ -1,12 +1,13 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 import logging
-from typing import Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Union
 
 import torch
 import torch.nn as nn
 from mmengine import print_log
 from mmengine.model.weight_init import (constant_init, kaiming_init,
                                         normal_init, xavier_init)
+from mmengine.registry import Registry
 from mmengine.utils.dl_utils.parrots_wrapper import _BatchNorm
 from torch import Tensor
 from torch.nn import init
@@ -232,3 +233,22 @@ def get_valid_num_batches(batch_inputs: Optional[ForwardInputs] = None,
             ' Please check your input carefully.')
 
     return num_batches_inputs or num_batches_samples
+
+
+def build_module(module: Union[dict, nn.Module], builder: Registry) -> Any:
+    """Build module from config or return the module itself.
+
+    Args:
+        module (Union[dict, nn.Module]): The module to build.
+        builder (Registry): The registry to build module.
+
+    Returns:
+        Any: The built module.
+    """
+    if isinstance(module, dict):
+        return builder.build(module)
+    elif isinstance(module, nn.Module):
+        return module
+    else:
+        raise TypeError(
+            f'Only support dict and nn.Module, but got {type(module)}.')

--- a/tests/test_models/test_base_archs/test_wrapper.py
+++ b/tests/test_models/test_base_archs/test_wrapper.py
@@ -10,11 +10,14 @@ from mmengine.utils import digit_version
 from mmengine.utils.dl_utils import TORCH_VERSION
 
 from mmedit.registry import MODELS
+from mmedit.utils import register_all_modules
 
 test_dir = osp.join(osp.dirname(__file__), '../../..', 'tests')
 config_path = osp.join(test_dir, 'configs', 'diffuser_wrapper_cfg')
 model_path = osp.join(test_dir, 'configs', 'tmp_weight')
 ckpt_path = osp.join(test_dir, 'configs', 'ckpt')
+
+register_all_modules()
 
 
 class TestWrapper(TestCase):

--- a/tests/test_models/test_diffusion_schedulers/test_init.py
+++ b/tests/test_models/test_diffusion_schedulers/test_init.py
@@ -1,0 +1,48 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+import os.path as osp
+import shutil
+from unittest import TestCase
+
+from mmedit.registry import DIFFUSION_SCHEDULERS
+
+test_dir = osp.join(osp.dirname(__file__), '../../..', 'tests')
+config_path = osp.join(test_dir, 'configs', 'scheduler_cfg')
+
+
+class TestWrapper(TestCase):
+
+    def test_build(self):
+        # 1. test init by args
+        config = dict(
+            type='EulerDiscreteScheduler',
+            num_train_timesteps=2000,
+            beta_schedule='scaled_linear')
+        scheduler = DIFFUSION_SCHEDULERS.build(config)
+        self.assertEqual(scheduler.num_train_timesteps, 2000)
+        self.assertEqual(scheduler.beta_schedule, 'scaled_linear')
+        scheduler_str = repr(scheduler)
+        self.assertIn(
+            'Wrapped Scheduler Class: '
+            '<class \'diffusers.schedulers.'
+            'scheduling_euler_discrete.'
+            'EulerDiscreteScheduler\'>', scheduler_str)
+        self.assertIn('Wrapped Scheduler Name: EulerDiscreteScheduler',
+                      scheduler_str)
+        self.assertNotIn('From Pretrained: ', scheduler_str)
+
+        # 2. test save as diffuser
+        scheduler.save_pretrained(config_path)
+
+        # 3. test from_pretrained
+        config = dict(
+            type='EulerDiscreteScheduler', from_pretrained=config_path)
+        scheduler = DIFFUSION_SCHEDULERS.build(config)
+        scheduler_str = repr(scheduler)
+        self.assertIn('From Pretrained: ', scheduler_str)
+
+        # 4. test attribute error
+        with self.assertRaises(AttributeError):
+            scheduler.unsupported_attr('do not support')
+
+        # tear down
+        shutil.rmtree(config_path)

--- a/tests/test_models/test_editors/test_ddpm/test_denoising_unet.py
+++ b/tests/test_models/test_editors/test_ddpm/test_denoising_unet.py
@@ -9,7 +9,7 @@ def test_DenoisingUnet():
     input = torch.rand((1, 3, 32, 32))
     unet = DenoisingUnet(32)
     output = unet.forward(input, 10)
-    assert output['outputs'].shape == (1, 6, 32, 32)
+    assert output['sample'].shape == (1, 6, 32, 32)
 
 
 def test_NormWithEmbedding():

--- a/tests/test_models/test_editors/test_stable_diffusion/test_stable_diffusion.py
+++ b/tests/test_models/test_editors/test_stable_diffusion/test_stable_diffusion.py
@@ -88,8 +88,7 @@ model = dict(
     vae=vae,
     init_cfg=init_cfg,
     text_encoder=dummy_text_encoder(),
-    tokenizer=dummy_text_encoder(),
-    unet_sample_size=64)
+    tokenizer=dummy_text_encoder())
 
 
 @pytest.mark.skipif(

--- a/tests/test_models/test_editors/test_stable_diffusion/test_stable_diffusion.py
+++ b/tests/test_models/test_editors/test_stable_diffusion/test_stable_diffusion.py
@@ -57,6 +57,7 @@ init_cfg = dict(type='Pretrained', pretrained_model_path=None)
 class dummy_tokenizer(nn.Module):
 
     def __init__(self):
+        super().__init__()
         self.model_max_length = 0
 
     def __call__(self,
@@ -74,6 +75,7 @@ class dummy_tokenizer(nn.Module):
 class dummy_text_encoder(nn.Module):
 
     def __init__(self):
+        super().__init__()
         self.config = None
 
     def __call__(self, x, attention_mask):

--- a/tests/test_models/test_editors/test_stable_diffusion/test_stable_diffusion.py
+++ b/tests/test_models/test_editors/test_stable_diffusion/test_stable_diffusion.py
@@ -3,6 +3,7 @@ import platform
 
 import pytest
 import torch
+import torch.nn as nn
 from addict import Dict
 from mmengine import MODELS, Config
 
@@ -12,41 +13,32 @@ register_all_modules()
 
 unet = dict(
     type='DenoisingUnet',
-    image_size=512,
-    base_channels=320,
-    channels_cfg=[1, 2, 4, 4],
+    image_size=128,
+    base_channels=32,
+    channels_cfg=[1, 2],
     unet_type='stable',
     act_cfg=dict(type='silu', inplace=False),
     cross_attention_dim=768,
-    num_heads=8,
+    num_heads=2,
     in_channels=4,
-    layers_per_block=2,
-    down_block_types=[
-        'CrossAttnDownBlock2D', 'CrossAttnDownBlock2D', 'CrossAttnDownBlock2D',
-        'DownBlock2D'
-    ],
-    up_block_types=[
-        'UpBlock2D', 'CrossAttnUpBlock2D', 'CrossAttnUpBlock2D',
-        'CrossAttnUpBlock2D'
-    ],
+    layers_per_block=1,
+    down_block_types=['CrossAttnDownBlock2D', 'DownBlock2D'],
+    up_block_types=['UpBlock2D', 'CrossAttnUpBlock2D'],
     output_cfg=dict(var='fixed'))
 
 vae = dict(
+    type='EditAutoencoderKL',
     act_fn='silu',
-    block_out_channels=[128, 256, 512, 512],
-    down_block_types=[
-        'DownEncoderBlock2D', 'DownEncoderBlock2D', 'DownEncoderBlock2D',
-        'DownEncoderBlock2D'
-    ],
+    block_out_channels=[128],
+    down_block_types=['DownEncoderBlock2D'],
     in_channels=3,
     latent_channels=4,
-    layers_per_block=2,
+    layers_per_block=1,
     norm_num_groups=32,
     out_channels=3,
-    sample_size=512,
+    sample_size=128,
     up_block_types=[
-        'UpDecoderBlock2D', 'UpDecoderBlock2D', 'UpDecoderBlock2D',
-        'UpDecoderBlock2D'
+        'UpDecoderBlock2D',
     ])
 
 diffusion_scheduler = dict(
@@ -61,17 +53,8 @@ diffusion_scheduler = dict(
 
 init_cfg = dict(type='Pretrained', pretrained_model_path=None)
 
-model = dict(
-    type='StableDiffusion',
-    diffusion_scheduler=diffusion_scheduler,
-    unet=unet,
-    vae=vae,
-    init_cfg=init_cfg,
-    requires_safety_checker=False,
-)
 
-
-class dummy_tokenizer:
+class dummy_tokenizer(nn.Module):
 
     def __init__(self):
         self.model_max_length = 0
@@ -88,7 +71,7 @@ class dummy_tokenizer:
         return text_inputs
 
 
-class dummy_text_encoder:
+class dummy_text_encoder(nn.Module):
 
     def __init__(self):
         self.config = None
@@ -96,6 +79,17 @@ class dummy_text_encoder:
     def __call__(self, x, attention_mask):
         result = torch.rand([1, 77, 768])
         return [result]
+
+
+model = dict(
+    type='StableDiffusion',
+    scheduler=diffusion_scheduler,
+    unet=unet,
+    vae=vae,
+    init_cfg=init_cfg,
+    text_encoder=dummy_text_encoder(),
+    tokenizer=dummy_text_encoder(),
+    unet_sample_size=64)
 
 
 @pytest.mark.skipif(
@@ -116,6 +110,13 @@ def test_stable_diffusion():
         'an insect robot preparing a delicious meal',
         height=64,
         width=64,
-        num_inference_steps=1)
+        num_inference_steps=1,
+        return_type='numpy')
+    assert result['samples'].shape == (1, 3, 64, 64)
 
-    assert result['samples'].shape == (3, 64, 64)
+    result = StableDiffuser.infer(
+        'an insect robot preparing a delicious meal',
+        height=64,
+        width=64,
+        num_inference_steps=1,
+        return_type='image')

--- a/tools/train.py
+++ b/tools/train.py
@@ -72,7 +72,7 @@ def main():
     # enable automatic-mixed-precision training
     if args.amp is True:
         if ('constructor' not in cfg.optim_wrapper) or \
-                cfg.optim_wrapper['constructor'] == 'DefaultOptimWrapperConstructor': # noqa
+                cfg.optim_wrapper['constructor'] == 'DefaultOptimWrapperConstructor':  # noqa
             optim_wrapper = cfg.optim_wrapper.type
             if optim_wrapper == 'AmpOptimWrapper':
                 print_colored_log(


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Support more flexible initialization for `StableDiffusion`.

## Modification

1. Revise the initialization function for `StableDiffusion`
2. Revise the output type of `StableDiffusion.infer`
3. Add some necessary attribute and method for `DenoisingUnet` and `DDIMScheduler`.
4. Register MMEdit's `AutoencoderKL` as `EditAutoencoderKL` to support build from config.
5. Support a wrapper for diffusers scheduler to support load from pretrained.
6. Revise some docstring and remove some useless comments.

## Who can help? @ them here!

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

**Before PR**:

- [x] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmediting/blob/master/.github/CONTRIBUTING.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmediting/blob/master/.github/CONTRIBUTING.md) are used to fix the potential lint issues.
- [x] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [x] If the modification has potential influence on downstream or other related projects, this PR should be tested with some of those projects.
- [x] CLA has been signed and all committers have signed the CLA in this PR.
