### PR TITLE
[Enhancement] Support evaluator without metric

### DIFF
--- a/mmedit/engine/runner/edit_loops.py
+++ b/mmedit/engine/runner/edit_loops.py
@@ -148,8 +148,9 @@ class EditValLoop(BaseLoop):
         # Input type checking and packing
         # 1. Single evaluator without type: [dict(), dict(), ...]
         # 2. Single evaluator with type: dict(type=xx, metrics=xx)
-        # 3. Multi evaluator without type: [[dict, ...], [dict, ...]]
-        # 4. Multi evaluator with type: [dict(type=xx, metrics=xx), dict(...)]
+        # 3. Single evaluator (metric): dict(type=METRIC)
+        # 4. Multi evaluator without type: [[dict, ...], [dict, ...]]
+        # 5. Multi evaluator with type: [dict(type=xx, metrics=xx), dict(...)]
         if is_evaluator(evaluator):
             evaluator = [update_and_check_evaluator(evaluator)]
         else:
@@ -398,8 +399,9 @@ class EditTestLoop(BaseLoop):
         # Input type checking and packing
         # 1. Single evaluator without type: [dict(), dict(), ...]
         # 2. Single evaluator with type: dict(type=xx, metrics=xx)
-        # 3. Multi evaluator without type: [[dict, ...], [dict, ...]]
-        # 4. Multi evaluator with type: [dict(type=xx, metrics=xx), dict(...)]
+        # 3. Single evaluator (metric): dict(type=METRIC)
+        # 4. Multi evaluator without type: [[dict, ...], [dict, ...]]
+        # 5. Multi evaluator with type: [dict(type=xx, metrics=xx), dict(...)]
         if is_evaluator(evaluator):
             evaluator = [update_and_check_evaluator(evaluator)]
         else:

--- a/mmedit/engine/runner/edit_loops.py
+++ b/mmedit/engine/runner/edit_loops.py
@@ -148,9 +148,8 @@ class EditValLoop(BaseLoop):
         # Input type checking and packing
         # 1. Single evaluator without type: [dict(), dict(), ...]
         # 2. Single evaluator with type: dict(type=xx, metrics=xx)
-        # 3. Single evaluator (metric): dict(type=METRIC)
-        # 4. Multi evaluator without type: [[dict, ...], [dict, ...]]
-        # 5. Multi evaluator with type: [dict(type=xx, metrics=xx), dict(...)]
+        # 3. Multi evaluator without type: [[dict, ...], [dict, ...]]
+        # 4. Multi evaluator with type: [dict(type=xx, metrics=xx), dict(...)]
         if is_evaluator(evaluator):
             evaluator = [update_and_check_evaluator(evaluator)]
         else:
@@ -399,9 +398,8 @@ class EditTestLoop(BaseLoop):
         # Input type checking and packing
         # 1. Single evaluator without type: [dict(), dict(), ...]
         # 2. Single evaluator with type: dict(type=xx, metrics=xx)
-        # 3. Single evaluator (metric): dict(type=METRIC)
-        # 4. Multi evaluator without type: [[dict, ...], [dict, ...]]
-        # 5. Multi evaluator with type: [dict(type=xx, metrics=xx), dict(...)]
+        # 3. Multi evaluator without type: [[dict, ...], [dict, ...]]
+        # 4. Multi evaluator with type: [dict(type=xx, metrics=xx), dict(...)]
         if is_evaluator(evaluator):
             evaluator = [update_and_check_evaluator(evaluator)]
         else:

--- a/mmedit/engine/runner/loop_utils.py
+++ b/mmedit/engine/runner/loop_utils.py
@@ -40,6 +40,7 @@ def update_and_check_evaluator(evaluator: EVALUATOR_TYPE
         'Can only conduct check and update for list of metrics, a config dict '
         f'or a Evaluator object. But receives {type(evaluator)}.')
     evaluator.setdefault('type', 'EditEvaluator')
+    evaluator.setdefault('metrics', None)  # default as 'dummy evaluator'
     _type = evaluator['type']
     if _type != 'EditEvaluator':
         print_log(warning_template.format(_type), 'current', WARNING)
@@ -57,7 +58,7 @@ def is_evaluator(evaluator: Any) -> bool:
             object.
     """
     # Single evaluator with type
-    if isinstance(evaluator, dict) and 'metrics' in evaluator:
+    if isinstance(evaluator, dict) and 'type' in evaluator:
         return True
     # Single evaluator without type
     elif (is_list_of(evaluator, dict)

--- a/mmedit/engine/runner/loop_utils.py
+++ b/mmedit/engine/runner/loop_utils.py
@@ -58,7 +58,7 @@ def is_evaluator(evaluator: Any) -> bool:
             object.
     """
     # Single evaluator with type
-    if isinstance(evaluator, dict) and 'type' in evaluator:
+    if isinstance(evaluator, dict) and 'metrics' in evaluator:
         return True
     # Single evaluator without type
     elif (is_list_of(evaluator, dict)

--- a/mmedit/evaluation/evaluator.py
+++ b/mmedit/evaluation/evaluator.py
@@ -44,7 +44,10 @@ class EditEvaluator(Evaluator):
     """
 
     def __init__(self, metrics: Union[dict, BaseMetric, Sequence]):
-        super().__init__(metrics)
+        if metrics is not None:
+            super().__init__(metrics)
+        else:
+            self.metrics = None
         self.is_ready = False
 
     def prepare_metrics(self, module: BaseModel, dataloader: DataLoader):
@@ -64,6 +67,10 @@ class EditEvaluator(Evaluator):
             module (BaseModel): Model to evaluate.
             dataloader (DataLoader): The dataloader for real images.
         """
+        if self.metrics is None:
+            self.is_ready = True
+            return
+
         if self.is_ready:
             return
 
@@ -108,6 +115,9 @@ class EditEvaluator(Evaluator):
             List[Tuple[List[BaseMetric], Iterator]]: A list of "metrics-shared
                 sampler" pair.
         """
+        if self.metrics is None:
+            return [[[None], []]]
+
         # grouping metrics based on `SAMPLER_MODE` and `sample_mode`
         metric_mode_dict = defaultdict(list)
         for metric in self.metrics:
@@ -137,6 +147,8 @@ class EditEvaluator(Evaluator):
                 metrics specific sampler or the dataloader.
             metrics (Optional[Sequence[BaseMetric]]): Metrics to evaluate.
         """
+        if self.metrics is None:
+            return
 
         _data_samples = []
         for data_sample in data_samples:
@@ -159,6 +171,8 @@ class EditEvaluator(Evaluator):
             dict: Evaluation results of all metrics. The keys are the names
                 of the metrics, and the values are corresponding results.
         """
+        if self.metrics is None:
+            return {'No Metric': 'Nan'}
         metrics = {}
         for metric in self.metrics:
             _results = metric.evaluate()

--- a/tests/test_engine/test_runner/test_loop_utils.py
+++ b/tests/test_engine/test_runner/test_loop_utils.py
@@ -26,7 +26,7 @@ def test_is_evaluator():
     assert not is_evaluator(evaluator)
 
     evaluator = dict(type='PSNR')
-    assert not is_evaluator(evaluator)
+    assert is_evaluator(evaluator)
 
 
 def test_update_and_check_evaluator():
@@ -58,3 +58,7 @@ def test_update_and_check_evaluator():
     evaluator = dict(type='EditEvaluator', metrics=[dict(type='PSNR')])
     evaluator = update_and_check_evaluator(evaluator)
     assert evaluator['type'] == 'EditEvaluator'
+
+    evaluator = dict(type='EditEvaluator')
+    evaluator = update_and_check_evaluator(evaluator)
+    assert evaluator['metrics'] is None

--- a/tests/test_engine/test_runner/test_loop_utils.py
+++ b/tests/test_engine/test_runner/test_loop_utils.py
@@ -26,7 +26,7 @@ def test_is_evaluator():
     assert not is_evaluator(evaluator)
 
     evaluator = dict(type='PSNR')
-    assert is_evaluator(evaluator)
+    assert not is_evaluator(evaluator)
 
 
 def test_update_and_check_evaluator():

--- a/tests/test_evaluation/test_evaluator.py
+++ b/tests/test_evaluation/test_evaluator.py
@@ -182,3 +182,29 @@ class TestEditEvaluator(TestCase):
         evaluator.metrics = [metric_mock3, metric_mock4]
         with self.assertRaises(ValueError):
             evaluator.evaluate()
+
+
+class TestNonMetricEvaluator(TestCase):
+
+    def test_init(self):
+        evaluator = EditEvaluator(None)
+        self.assertIsNone(evaluator.metrics)
+
+    def test_prepare_metrics(self):
+        evaluator = EditEvaluator(None)
+        evaluator.prepare_metrics(None, None)
+        self.assertTrue(evaluator.is_ready)
+
+    def test_prepare_samplers(self):
+        evaluator = EditEvaluator(None)
+        metric_sampler_list = evaluator.prepare_samplers(None, None)
+        self.assertEqual(metric_sampler_list, [[[None], []]])
+
+    def test_process(self):
+        evaluator = EditEvaluator(None)
+        evaluator.process(None, None, None)
+
+    def test_evalute(self):
+        evaluator = EditEvaluator(None)
+        output = evaluator.evaluate()
+        self.assertEqual(output, {'No Metric': 'Nan'})


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Sometimes, we want to run **validation loop** for visualization and do not run an evaluation. Therefore we revise `EditEvaluator` to support **"non-metric"**.

## Modification

As title

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

**Before PR**:

- [x] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmediting/blob/master/.github/CONTRIBUTING.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmediting/blob/master/.github/CONTRIBUTING.md) are used to fix the potential lint issues.
- [x] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [x] If the modification has potential influence on downstream or other related projects, this PR should be tested with some of those projects.
- [x] CLA has been signed and all committers have signed the CLA in this PR.
