### PR TITLE
 [bugfix] No module named 'diffusers.models.unet_2d_condition'

### DIFF
--- a/mmagic/models/editors/vico/vico_utils.py
+++ b/mmagic/models/editors/vico/vico_utils.py
@@ -7,7 +7,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 from diffusers import Transformer2DModel
 from diffusers.models.attention import Attention, BasicTransformerBlock
-from diffusers.models.unet_2d_condition import UNet2DConditionOutput
+from diffusers.models.unets.unet_2d_condition import UNet2DConditionOutput
 from diffusers.utils import BaseOutput, is_torch_version
 
 


### PR DESCRIPTION
## Motivation

bugfix for No module named 'diffusers.models.unet_2d_condition'

## Modification

The latest version of diffusers has modified its file organization structure.
Change import path for diffusers.

## Checklist

Submitting this pull request means that,

**Before PR**:

- [x] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmagic/blob/main/.github/CONTRIBUTING.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmagic/blob/main/.github/CONTRIBUTING.md) are used to fix the potential lint issues.
- [] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [] If the modification has potential influence on downstream or other related projects, this PR should be tested with some of those projects.
- [x] CLA has been signed and all committers have signed the CLA in this PR.



















