### PR TITLE
[Chore] add initial support for PEP517 builds

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "torch", "torchvision"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
## Motivation

An issue was raised at python-poetry/poetry#9707 indicating that PEP517 builds of this project was failing due to missing build system requirement declaration.

## Modification

This change adds initial pyproject.toml file to allow PEP517 builds.

## Use cases

The project can now be build correctly by PEP517 front ends. For example, with this change the following command will work.

```sh
python3.8 -m pip wheel 'git+https://github.com/open-mmlab/mmagic.git'
```

You can test the changes using the following command.

```sh
python3.8 -m pip wheel 'git+https://github.com/open-mmlab/mmagic.git@refs/pull/2154/head'
```

## Checklist

Submitting this pull request means that,

**Before PR**:

- [x] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmagic/blob/main/.github/CONTRIBUTING.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmagic/blob/main/.github/CONTRIBUTING.md) are used to fix the potential lint issues.
- [x] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [x] If the modification has potential influence on downstream or other related projects, this PR should be tested with some of those projects.
- [x] CLA has been signed and all committers have signed the CLA in this PR.
