### PR TITLE
Update __init__.py

### DIFF
--- a/mmagic/__init__.py
+++ b/mmagic/__init__.py
@@ -32,11 +32,11 @@ mmengine_min_version = digit_version(MMENGINE_MIN)
 mmengine_max_version = digit_version(MMENGINE_MAX)
 mmengine_version = digit_version(mmengine.__version__)
 
-assert (mmcv_min_version <= mmcv_version < mmcv_max_version), \
+assert (mmcv_min_version <= mmcv_version <= mmcv_max_version), \
     f'mmcv=={mmcv.__version__} is used but incompatible. ' \
     f'Please install mmcv-full>={mmcv_min_version}, <{mmcv_max_version}.'
 
-assert (mmengine_min_version <= mmengine_version < mmengine_max_version), \
+assert (mmengine_min_version <= mmengine_version <= mmengine_max_version), \
     f'mmengine=={mmengine.__version__} is used but incompatible. ' \
     f'Please install mmengine>={mmengine_min_version}, ' \
     f'<{mmengine_max_version}.'


### PR DESCRIPTION
mmcv 2.2.0 version compatible

Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

I wanted to use RealBasicVSR for my video restoration tasks but everytime i install mmcv its deafult version is 2.2.0 and if i try to install any other version it takes too much time to build the wheel.

## Modification

In mmagic _init__.py, just changed the "mmcv_min_version <= mmcv_version < mmcv_max_version" to "**mmcv_min_version <= mmcv_version <= mmcv_max_version**" and  "mmengine_min_version <= mmengine_version < mmengine_max_version" to "**mmengine_min_version <= mmengine_version <= mmengine_max_version**" (for future if any similar error happens becuase of mmengine)

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

Submitting this pull request means that,

**Before PR**:

- [x] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmagic/blob/main/.github/CONTRIBUTING.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmagic/blob/main/.github/CONTRIBUTING.md) are used to fix the potential lint issues.
- [x] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [x] If the modification has potential influence on downstream or other related projects, this PR should be tested with some of those projects.
- [x] CLA has been signed and all committers have signed the CLA in this PR.
